### PR TITLE
chore: separate gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,31 +1,23 @@
-buildscript {
-    ext {
-        queryDslVersion = "5.0.0"
-    }
-}
-
 plugins {
-    id 'org.springframework.boot' version '2.7.11'
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id 'java'
+    id 'org.springframework.boot' version "${springBootVersion}"
+    id 'io.spring.dependency-management' version "${springDependencyManagementVersion}"
+    id 'com.ewerk.gradle.plugins.querydsl'
 }
 
-group = 'usw.suwiki'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
+group = "${projectGroup}"
+version = "${applicationVersion}"
+sourceCompatibility = "${javaVersion}"
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
+jar.enabled = false
 
+apply from: 'gradle/lombok.gradle'
+apply from: 'gradle/querydsl.gradle'
+apply from: 'gradle/testsupport.gradle'
 
 repositories {
     mavenCentral()
 }
-
 
 dependencies {
 
@@ -53,30 +45,13 @@ dependencies {
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-    // Querydsl
-    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
-    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
-
-    // Utils
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    implementation 'org.modelmapper:modelmapper:3.1.1'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-
     // SMTP
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
-    // Test
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
-    implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testCompileOnly 'org.projectlombok:lombok:1.18.22'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'
-    implementation 'org.apache.commons:commons-text:1.10.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+    // Utils
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.modelmapper:modelmapper:3.1.1'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
@@ -87,29 +62,6 @@ tasks.named('test') {
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
     options.release = 17 // Java 17을 사용할 경우 release 17로 설정
-}
-
-// Querydsl 추가 설정.
-def querydslDir = "$buildDir/generated/querydsl"
-// JPA 사용 여부와 사용할 경로를 설정
-querydsl {
-    jpa = true
-    querydslSourcesDir = querydslDir
-}
-// build 시 사용할 sourceSet 추가
-sourceSets {
-    main.java.srcDir querydslDir
-}
-// querydsl 컴파일시 사용할 옵션 설정
-compileQuerydsl {
-    options.annotationProcessorPath = configurations.querydsl
-}
-// querydsl 이 compileClassPath 를 상속하도록 설정
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-    querydsl.extendsFrom compileClasspath
 }
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,14 @@
+### Application version ###
+applicationVersion=0.0.1-SNAPSHOT
+
+### Project configs ###
+projectGroup=usw.suwiki
+javaVersion=17
+
+### Spring dependency versions ###
+springBootVersion=2.7.11
+springDependencyManagementVersion=1.0.11.RELEASE
+
+### Querydsl versions ###
+queryDslVersion=5.0.0
+gradlePluginsQuerydslVersion=1.0.10

--- a/gradle/lombok.gradle
+++ b/gradle/lombok.gradle
@@ -1,0 +1,11 @@
+configurations {
+    compileOnly.extendsFrom annotationProcessor
+}
+
+dependencies {
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testCompileOnly 'org.projectlombok:lombok:1.18.22'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'
+}

--- a/gradle/querydsl.gradle
+++ b/gradle/querydsl.gradle
@@ -1,0 +1,30 @@
+apply plugin: 'com.ewerk.gradle.plugins.querydsl'
+
+dependencies {
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+}
+
+// Querydsl 추가 설정.
+def querydslDir = "$buildDir/generated/querydsl"
+
+// JPA 사용 여부와 사용할 경로를 설정
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+// build 시 사용할 sourceSet 추가
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+// querydsl 컴파일시 사용할 옵션 설정
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+
+// querydsl 이 compileClassPath 를 상속하도록 설정
+configurations {
+    querydsl.extendsFrom compileClasspath
+}

--- a/gradle/testsupport.gradle
+++ b/gradle/testsupport.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+    implementation 'org.apache.commons:commons-text:1.10.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,7 @@
+pluginManagement {
+    plugins {
+        id 'com.ewerk.gradle.plugins.querydsl' version "${gradlePluginsQuerydslVersion}"
+    }
+}
+
 rootProject.name = 'suwiki'


### PR DESCRIPTION
## 🙋 어떤 PR인가요?
gradle에 의존성을 분리했습니다.

## 📝 작업 상세
#### 1. 불필요한 의존성 제거
`org.springframework.security:spring-security-test`은 `org.springframework.boot:spring-boot-starter-test`은 같은 의존성을 가지고 있습니다.

#### 2. 중복된 의존성 제거
`org.springframework.boot:spring-boot-starter-test`이 2번 작성되어있습니다.

#### 3. gradle script 분리
기존 gradle 스크립트가 너무 길어서 2가지 기준을 가지고 분리했습니다.
 1. 추후에 멀티모듈 구조로 변경되어도 전역적으로 사용될 의존성 분리 (`lombok`, `test dependencies`)
 2. 길어서 build.gradle의 가독성을 해치는 의존성 (`querydsl`)

#### 4. gradle.properties 분리
기존에 querydsl만 전역 변수로 두고 사용하고 있습니다.
통일성을 위해서 파일(`gradle.properties`)을 분리해서 사용하도록 수정하였습니다.

## 🙏 To Reviewers
분리가 불필요한 작업일 수도 있습니다 🥹
향후를 대비해서 분리해보았습니다.