### PR TITLE
hotfix: 토큰 재발급 에러

### DIFF
--- a/src/main/java/usw/suwiki/domain/refreshtoken/service/RefreshTokenCRUDService.java
+++ b/src/main/java/usw/suwiki/domain/refreshtoken/service/RefreshTokenCRUDService.java
@@ -7,6 +7,8 @@ import usw.suwiki.domain.refreshtoken.RefreshToken;
 import usw.suwiki.domain.refreshtoken.repository.RefreshTokenRepository;
 
 import java.util.Optional;
+import usw.suwiki.global.exception.ExceptionType;
+import usw.suwiki.global.exception.errortype.AccountException;
 
 @Service
 @Transactional
@@ -29,7 +31,8 @@ public class RefreshTokenCRUDService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<RefreshToken> loadRefreshTokenFromPayload(String payload) {
-        return refreshTokenRepository.findByPayload(payload);
+    public RefreshToken loadRefreshTokenFromPayload(String payload) {
+        return refreshTokenRepository.findByPayload(payload)
+                .orElseThrow(()->new AccountException(ExceptionType.TOKEN_IS_BROKEN));
     }
 }

--- a/src/main/java/usw/suwiki/domain/user/user/service/UserBusinessService.java
+++ b/src/main/java/usw/suwiki/domain/user/user/service/UserBusinessService.java
@@ -217,13 +217,13 @@ public class UserBusinessService {
 
     public Map<String, String> executeJWTRefreshForWebClient(Cookie requestRefreshCookie) {
         String payload = requestRefreshCookie.getValue();
-        RefreshToken refreshToken = refreshTokenCRUDService.loadRefreshTokenFromPayload(payload).get();
+        RefreshToken refreshToken = refreshTokenCRUDService.loadRefreshTokenFromPayload(payload);
         User user = userCRUDService.loadUserFromUserIdx(refreshToken.getUserIdx());
         return refreshUserJWT(user, payload);
     }
 
-    public Map<String, String> executeJWTRefreshForMobileClient(String Authorization) {
-        RefreshToken refreshToken = refreshTokenCRUDService.loadRefreshTokenFromPayload(Authorization).get();
+    public Map<String, String> executeJWTRefreshForMobileClient(String payload) {
+        RefreshToken refreshToken = refreshTokenCRUDService.loadRefreshTokenFromPayload(payload);
         User user = userCRUDService.loadUserFromUserIdx(refreshToken.getUserIdx());
         return refreshUserJWT(user, refreshToken.getPayload());
     }

--- a/src/main/java/usw/suwiki/domain/user/user/service/UserBusinessService.java
+++ b/src/main/java/usw/suwiki/domain/user/user/service/UserBusinessService.java
@@ -337,7 +337,7 @@ public class UserBusinessService {
     private Map<String, String> refreshUserJWT(User user, String refreshTokenPayload) {
         return new HashMap<>() {{
             put("AccessToken", jwtAgent.createAccessToken(user));
-            put("RefreshToken", jwtAgent.refreshTokenRefresh(refreshTokenPayload));
+            put("RefreshToken", jwtAgent.reissueRefreshToken(refreshTokenPayload));
         }};
     }
 

--- a/src/main/java/usw/suwiki/global/jwt/JwtAgent.java
+++ b/src/main/java/usw/suwiki/global/jwt/JwtAgent.java
@@ -32,13 +32,11 @@ public class JwtAgent {
     @Value("${spring.secret-key}")
     private String key;
 
-    // TODO: 토큰 만료 시간 설정 외부 yml 파일로 이동
-    private static final Long ACCESS_TOKEN_EXPIRE_TIME = 30 * 60 * 1000L; // 30분
-    private static final Long REFRESH_TOKEN_EXPIRE_TIME = 270 * 24 * 60 * 60 * 1000L; // 270일 -> 9개월
+    @Value("${jwt.access-duration}")
+    public long accessTokenExpireTime;
 
-    // TODO: 다시 바꾸기
-//    private static final Long ACCESS_TOKEN_EXPIRE_TIME = 1 * 60 * 1000L; // 1분
-//    private static final Long REFRESH_TOKEN_EXPIRE_TIME = 3 * 60 * 1000L; // 3분
+    @Value("${jwt.refresh-duration}")
+    public long refreshTokenExpireTime;
 
     private final RefreshTokenCRUDService refreshTokenCRUDService;
 

--- a/src/main/java/usw/suwiki/global/jwt/JwtAgent.java
+++ b/src/main/java/usw/suwiki/global/jwt/JwtAgent.java
@@ -63,8 +63,8 @@ public class JwtAgent {
     }
 
     @Transactional
-    public String refreshTokenRefresh(String payload) { // TODO: 메서드명 리팩토링 refresh -> reissue
-        // TODO: 재발급 로직 고민. Security 공부하면서 정말 필요한 로직만 넣자.
+    public String reissueRefreshToken(String payload) {
+        // TODO: Security 공부하면서 정말 필요한 로직만 넣자.
         // TODO: 레디스 캐싱 성능 개선
 
         // RefreshToken 엔티티 조회
@@ -87,7 +87,7 @@ public class JwtAgent {
     @Transactional
     public String reIssueRefreshToken(RefreshToken refreshToken) {
         refreshToken.updatePayload(
-                buildRefreshToken(new Date(new Date().getTime() + REFRESH_TOKEN_EXPIRE_TIME))
+                buildRefreshToken(new Date(new Date().getTime() + refreshTokenExpireTime))
         );
         return refreshToken.getPayload();
     }
@@ -107,12 +107,12 @@ public class JwtAgent {
     public String createAccessToken(User user) {
         return buildAccessToken(
                 setAccessTokenClaimsByUser(user),
-                new Date(new Date().getTime() + ACCESS_TOKEN_EXPIRE_TIME)
+                new Date(new Date().getTime() + accessTokenExpireTime)
         );
     }
 
     public String createRefreshToken(User user) {
-        String buildRefreshToken = buildRefreshToken(new Date(new Date().getTime() + REFRESH_TOKEN_EXPIRE_TIME));
+        String buildRefreshToken = buildRefreshToken(new Date(new Date().getTime() + refreshTokenExpireTime));
         refreshTokenCRUDService.save(RefreshToken.buildRefreshToken(user.getId(), buildRefreshToken));
 
         return buildRefreshToken;


### PR DESCRIPTION
## 🙋 어떤 PR인가요?
기존 `refreshTokenRefresh` 메서드에서 토큰 만료기한에 대한 분기처리 오류가 있었습니다.
검증 로직을 수정하고, 기존 '만료기한이 7일 이하로 남은' 토큰에 대한 메서드를 제거했습니다.
해당 메서드는 리팩토링 후 다시 추가할 예정입니다.

## 📝 작업 상세
- `refreshTokenRefresh` 수정
- `refreshTokenRefresh` -> `reissueRefreshToken` 메서드명 변경
- 토큰 만료기간 상수를 yml에서 관리하도록 수정

## 🙏 To Reviewers
앞으로 개발 서버의 토큰 만료 기간은 access : 1분, refresh : 3분입니다.
클라이언트측의 개발 편의를 위한 수정이며 변경될 수 있습니다.

운영 서버 applicationl-key.yml, 개발 서버 application-dev.yml 수정되었습니다

## 🧐 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
- [x]  정상동작하는지, 테스트 통과하는지 다시 한번 확인해주세요.
