### PR TITLE
시간표 생성시 현재 학기 강의 검색 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build/
 /src/main/resources/application-prod.yml
 /src/main/resources/application-dev.yml
 /src/main/resources/application-local.yml
-/src/test/resources/*.yml
 
 *.json
 *.DS_Store

--- a/src/main/java/usw/suwiki/domain/evaluatepost/service/EvaluatePostService.java
+++ b/src/main/java/usw/suwiki/domain/evaluatepost/service/EvaluatePostService.java
@@ -1,5 +1,9 @@
 package usw.suwiki.domain.evaluatepost.service;
 
+import static usw.suwiki.global.exception.ExceptionType.POSTS_WRITE_OVERLAP;
+
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,15 +16,11 @@ import usw.suwiki.domain.evaluatepost.service.dto.EvaluatePostsToLecture;
 import usw.suwiki.domain.evaluatepost.service.dto.FindByLectureToJson;
 import usw.suwiki.domain.lecture.domain.Lecture;
 import usw.suwiki.domain.lecture.service.LectureCRUDService;
+import usw.suwiki.domain.lecture.service.LectureService;
 import usw.suwiki.domain.user.user.User;
 import usw.suwiki.domain.user.user.service.UserCRUDService;
 import usw.suwiki.global.PageOption;
 import usw.suwiki.global.exception.errortype.EvaluatePostException;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static usw.suwiki.global.exception.ExceptionType.POSTS_WRITE_OVERLAP;
 
 @Service
 @RequiredArgsConstructor
@@ -28,12 +28,13 @@ public class EvaluatePostService {
 
     private final EvaluatePostCRUDService evaluatePostCRUDService;
     private final LectureCRUDService lectureCRUDService;
+    private final LectureService lectureService;
     private final UserCRUDService userCRUDService;
 
     @Transactional
     public void write(EvaluatePostSaveDto evaluatePostData, Long userIdx, Long lectureId) {
         checkAlreadyWrite(userIdx, lectureId);
-        Lecture lecture = lectureCRUDService.loadLectureFromId(lectureId);
+        Lecture lecture = lectureService.findLectureById(lectureId);
         User user = userCRUDService.loadUserFromUserIdx(userIdx);
         EvaluatePost evaluatePost = createEvaluatePost(evaluatePostData, user, lecture);
 
@@ -104,7 +105,7 @@ public class EvaluatePostService {
     }
 
     public boolean verifyIsUserCanWriteEvaluatePost(Long userIdx, Long lectureId) {
-        Lecture lecture = lectureCRUDService.loadLectureFromId(lectureId);
+        Lecture lecture = lectureService.findLectureById(lectureId);;
         User user = userCRUDService.loadUserFromUserIdx(userIdx);
         return evaluatePostCRUDService.isAlreadyWritten(user, lecture);
     }

--- a/src/main/java/usw/suwiki/domain/exampost/service/ExamPostService.java
+++ b/src/main/java/usw/suwiki/domain/exampost/service/ExamPostService.java
@@ -1,22 +1,24 @@
 package usw.suwiki.domain.exampost.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import usw.suwiki.domain.exampost.controller.dto.*;
+import usw.suwiki.domain.exampost.controller.dto.ExamPostUpdateDto;
+import usw.suwiki.domain.exampost.controller.dto.ExamPostsSaveDto;
+import usw.suwiki.domain.exampost.controller.dto.ExamResponseByLectureIdDto;
+import usw.suwiki.domain.exampost.controller.dto.ExamResponseByUserIdxDto;
+import usw.suwiki.domain.exampost.controller.dto.ReadExamPostResponse;
 import usw.suwiki.domain.exampost.controller.dto.viewexam.PurchaseHistoryDto;
 import usw.suwiki.domain.exampost.domain.ExamPost;
-import usw.suwiki.domain.userlecture.viewexam.ViewExam;
 import usw.suwiki.domain.lecture.domain.Lecture;
-import usw.suwiki.domain.lecture.service.LectureCRUDService;
+import usw.suwiki.domain.lecture.service.LectureService;
 import usw.suwiki.domain.user.user.User;
 import usw.suwiki.domain.user.user.service.UserCRUDService;
+import usw.suwiki.domain.userlecture.viewexam.ViewExam;
 import usw.suwiki.domain.userlecture.viewexam.service.ViewExamCRUDService;
 import usw.suwiki.global.PageOption;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -24,12 +26,12 @@ public class ExamPostService {
 
     private final ExamPostCRUDService examPostCRUDService;
     private final ViewExamCRUDService viewExamCRUDService;
-    private final LectureCRUDService lectureCRUDService;
+    private final LectureService lectureService;
     private final UserCRUDService userCRUDService;
 
     @Transactional
     public void write(ExamPostsSaveDto examData, Long userIdx, Long lectureId) {
-        Lecture lecture = lectureCRUDService.loadLectureFromId(lectureId);
+        Lecture lecture = lectureService.findLectureById(lectureId);
         User user = userCRUDService.loadUserFromUserIdx(userIdx);
 
         ExamPost examPost = createExamPost(examData, user, lecture);
@@ -41,7 +43,7 @@ public class ExamPostService {
     @Transactional
     public void purchase(Long lectureIdx, Long userIdx) {
         User user = userCRUDService.loadUserFromUserIdx(userIdx);
-        Lecture lecture = lectureCRUDService.loadLectureFromId(lectureIdx);
+        Lecture lecture =lectureService.findLectureById(lectureIdx);
         user.purchaseExamPost();
 
         ViewExam viewExam = ViewExam.builder()
@@ -109,7 +111,7 @@ public class ExamPostService {
     @Transactional(readOnly = true)
     public boolean isWrite(Long userIdx, Long lectureIdx) {
         User user = userCRUDService.loadUserFromUserIdx(userIdx);
-        Lecture lecture = lectureCRUDService.loadLectureFromId(lectureIdx);
+        Lecture lecture = lectureService.findLectureById(lectureIdx);
         return examPostCRUDService.isWrite(user, lecture);
     }
 

--- a/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java
+++ b/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java
@@ -1,21 +1,29 @@
 package usw.suwiki.domain.lecture.controller;
 
+import static usw.suwiki.global.exception.ExceptionType.USER_RESTRICTED;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import usw.suwiki.domain.lecture.controller.dto.LectureAndCountResponseForm;
 import usw.suwiki.domain.lecture.controller.dto.LectureDetailResponseDto;
 import usw.suwiki.domain.lecture.controller.dto.LectureFindOption;
+import usw.suwiki.domain.lecture.controller.dto.LectureWithScheduleResponse;
 import usw.suwiki.domain.lecture.service.LectureService;
 import usw.suwiki.global.ResponseForm;
 import usw.suwiki.global.annotation.ApiLogger;
 import usw.suwiki.global.annotation.CacheStatics;
+import usw.suwiki.global.dto.ApiResponse;
+import usw.suwiki.global.dto.NoOffsetPaginationResponse;
 import usw.suwiki.global.exception.errortype.AccountException;
 import usw.suwiki.global.jwt.JwtAgent;
 import usw.suwiki.global.util.CacheStaticsLogger;
-
-import static usw.suwiki.global.exception.ExceptionType.USER_RESTRICTED;
 
 
 @RestController
@@ -41,6 +49,20 @@ public class LectureController {
                 searchValue, findOption);
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/current/cells/search")
+    public ResponseEntity<ApiResponse<NoOffsetPaginationResponse<LectureWithScheduleResponse>>> searchLectureCells(
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false, defaultValue = "20") Integer size,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String major,
+            @RequestParam(required = false) Integer grade
+    ) {
+        NoOffsetPaginationResponse<LectureWithScheduleResponse> response =
+                lectureService.findPagedLecturesWithSchedule(cursorId, size, keyword, major, grade);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Cacheable(cacheNames = "lecture")

--- a/src/main/java/usw/suwiki/domain/lecture/controller/dto/LectureWithScheduleResponse.java
+++ b/src/main/java/usw/suwiki/domain/lecture/controller/dto/LectureWithScheduleResponse.java
@@ -1,0 +1,42 @@
+package usw.suwiki.domain.lecture.controller.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import usw.suwiki.domain.lecture.domain.Lecture;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LectureWithScheduleResponse {
+    private long id;
+    private String name;
+    private String type;
+    private String major;
+    private int grade;
+    private String professorName;
+
+    private final List<OriginalLectureCellResponse> originalCellList = new ArrayList<>();
+
+    public static LectureWithScheduleResponse of(
+            Lecture lecture
+    ) {
+        return LectureWithScheduleResponse.builder()
+                .id(lecture.getId())
+                .name(lecture.getName())
+                .professorName(lecture.getProfessor())
+                .type(lecture.getType())
+                .major(lecture.getMajorType())
+                .grade(lecture.getLectureDetail().getGrade())
+                .build();
+    }
+
+    public void addOriginalCellResponse(OriginalLectureCellResponse cellResponse) {
+        this.originalCellList.add(cellResponse);
+    }
+}

--- a/src/main/java/usw/suwiki/domain/lecture/controller/dto/OriginalLectureCellResponse.java
+++ b/src/main/java/usw/suwiki/domain/lecture/controller/dto/OriginalLectureCellResponse.java
@@ -1,0 +1,28 @@
+package usw.suwiki.domain.lecture.controller.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import usw.suwiki.domain.timetable.entity.TimetableCellSchedule;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class OriginalLectureCellResponse {
+    private String location;
+    private String day;
+    private Integer startPeriod;
+    private Integer endPeriod;
+
+    public static OriginalLectureCellResponse of(TimetableCellSchedule schedule) {
+        return OriginalLectureCellResponse.builder()
+                .location(schedule.getLocation())
+                .day(schedule.getDay().getValue())
+                .startPeriod(schedule.getStartPeriod())
+                .endPeriod(schedule.getEndPeriod())
+                .build();
+    }
+}

--- a/src/main/java/usw/suwiki/domain/lecture/domain/LectureDetail.java
+++ b/src/main/java/usw/suwiki/domain/lecture/domain/LectureDetail.java
@@ -2,7 +2,6 @@ package usw.suwiki.domain.lecture.domain;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Embeddable
 @NoArgsConstructor
-public class LectureDetail {
+public class LectureDetail {	// TODO refactor: placeSchedule, grade, point 은 Lecture로 이동. 혹은 전체 이동.
 	@Column(name = "place_schedule")
 	private String placeSchedule;
 

--- a/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureCustomRepository.java
+++ b/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureCustomRepository.java
@@ -7,7 +7,7 @@ import usw.suwiki.domain.lecture.domain.Lecture;
 import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
 
 
-public interface LectureQueryRepository {
+public interface LectureCustomRepository {
     Slice<Lecture> findCurrentSemesterLecturesPage(
             final Long cursorId,
             final int limit,
@@ -16,13 +16,10 @@ public interface LectureQueryRepository {
             final Integer grade
     );
 
-    //
     Lecture verifyJsonLecture(String lectureName, String ProfessorName, String majorType);
 
-    //
     List<String> findAllMajorType();
 
-    //
     LecturesAndCountDao findLectureByFindOption(String searchValue, LectureFindOption lectureFindOption);
 
     LecturesAndCountDao findLectureByMajorType(String searchValue, LectureFindOption lectureFindOption);

--- a/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureCustomRepository.java
+++ b/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureCustomRepository.java
@@ -8,7 +8,7 @@ import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
 
 
 public interface LectureCustomRepository {
-    Slice<Lecture> findCurrentSemesterLecturesPage(
+    Slice<Lecture> findCurrentSemesterLectures(
             final Long cursorId,
             final int limit,
             final String keyword,

--- a/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureCustomRepositoryImpl.java
+++ b/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureCustomRepositoryImpl.java
@@ -21,7 +21,7 @@ import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
 import usw.suwiki.global.util.query.SlicePaginationUtils;
 
 @RequiredArgsConstructor
-public class LectureQueryRepositoryImpl implements LectureQueryRepository { // TODO style: Repository명 변경
+public class LectureCustomRepositoryImpl implements LectureCustomRepository { // TODO style: Repository명 변경
 
     private final JPAQueryFactory queryFactory;
     private final String DEFAULT_ORDER = "modifiedDate";

--- a/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureCustomRepositoryImpl.java
+++ b/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureCustomRepositoryImpl.java
@@ -32,7 +32,7 @@ public class LectureCustomRepositoryImpl implements LectureCustomRepository { //
     private String currentSemester; // TODO 고민: Lecture - currently_opened 혹은 last_opened_semester 컬럼 추가 -> 데이터 파싱 로직 및 WHERE절 변경해야 함.
 
     @Override
-    public Slice<Lecture> findCurrentSemesterLecturesPage(
+    public Slice<Lecture> findCurrentSemesterLectures(
             final Long cursorId,
             final int limit,
             final String keyword,

--- a/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureQueryRepository.java
+++ b/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureQueryRepository.java
@@ -1,21 +1,33 @@
 package usw.suwiki.domain.lecture.domain.repository;
 
-import org.springframework.data.jpa.repository.Query;
+import java.util.List;
+import org.springframework.data.domain.Slice;
 import usw.suwiki.domain.lecture.controller.dto.LectureFindOption;
 import usw.suwiki.domain.lecture.domain.Lecture;
 import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
 
-import java.util.List;
-
 
 public interface LectureQueryRepository {
+    Slice<Lecture> findCurrentSemesterLecturesPage(
+            final Long cursorId,
+            final int limit,
+            final String keyword,
+            final String majorType,
+            final Integer grade
+    );
+
     //
     Lecture verifyJsonLecture(String lectureName, String ProfessorName, String majorType);
+
     //
     List<String> findAllMajorType();
+
     //
     LecturesAndCountDao findLectureByFindOption(String searchValue, LectureFindOption lectureFindOption);
+
     LecturesAndCountDao findLectureByMajorType(String searchValue, LectureFindOption lectureFindOption);
+
     LecturesAndCountDao findAllLectureByFindOption(LectureFindOption lectureFindOption);
+
     LecturesAndCountDao findAllLectureByMajorType(LectureFindOption lectureFindOption);
 }

--- a/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureQueryRepositoryImpl.java
+++ b/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureQueryRepositoryImpl.java
@@ -6,22 +6,51 @@ import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import usw.suwiki.domain.lecture.controller.dto.LectureFindOption;
 import usw.suwiki.domain.lecture.domain.Lecture;
 import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
+import usw.suwiki.global.util.query.SlicePaginationUtils;
 
 @RequiredArgsConstructor
-public class LectureQueryRepositoryImpl implements LectureQueryRepository {
+public class LectureQueryRepositoryImpl implements LectureQueryRepository { // TODO style: Repository명 변경
 
     private final JPAQueryFactory queryFactory;
     private final String DEFAULT_ORDER = "modifiedDate";
     private final Integer DEFAULT_PAGE = 1;
     private final Integer DEFAULT_LIMIT = 10;
+
+    @Value("${business.current-semester}")
+    private String currentSemester; // TODO 고민: Lecture - currently_opened 혹은 last_opened_semester 컬럼 추가 -> 데이터 파싱 로직 및 WHERE절 변경해야 함.
+
+    @Override
+    public Slice<Lecture> findCurrentSemesterLecturesPage(
+            final Long cursorId,
+            final int limit,
+            final String keyword,
+            final String majorType,
+            final Integer grade
+    ) {
+        JPAQuery<Lecture> query = queryFactory.selectFrom(lecture)
+                .where(gtCursorId(cursorId))
+                .where(containsKeyword(keyword))
+                .where(eqMajorType(majorType))
+                .where(eqGrade(grade))
+                .where(lecture.semester.endsWith(currentSemester))
+                .orderBy(lecture.id.asc())
+                .limit(SlicePaginationUtils.increaseSliceLimit(limit));
+
+        return SlicePaginationUtils.buildSlice(query.fetch(), limit);
+    }
+
 
     @Override
     public Lecture verifyJsonLecture(String lectureName, String professorName, String majorType) {
@@ -38,12 +67,9 @@ public class LectureQueryRepositoryImpl implements LectureQueryRepository {
     }
 
 
-
-
     /**
-     * if (!Arrays.asList(orderOptions).contains(orderOption)) {
-     *     throw new AccountException(ExceptionType.INVALID_ORDER_OPTION);
-     * }
+     * if (!Arrays.asList(orderOptions).contains(orderOption)) { throw new
+     * AccountException(ExceptionType.INVALID_ORDER_OPTION); }
      */
     @Override
     public LecturesAndCountDao findLectureByFindOption(String searchValue, LectureFindOption option) {
@@ -53,7 +79,6 @@ public class LectureQueryRepositoryImpl implements LectureQueryRepository {
         BooleanExpression searchCondition = lecture.name
                 .likeIgnoreCase("%" + searchValue + "%")
                 .or(lecture.professor.likeIgnoreCase("%" + searchValue + "%"));
-
 
         OrderSpecifier<?> orderSpecifier = getOrderSpecifier(orderOption);
 
@@ -176,6 +201,34 @@ public class LectureQueryRepositoryImpl implements LectureQueryRepository {
                 .selectDistinct(lecture.majorType)
                 .from(lecture)
                 .fetch();
+    }
+
+    private BooleanExpression gtCursorId(Long cursorId) {
+        if (Objects.isNull(cursorId)) {
+            return null;
+        }
+        return lecture.id.gt(cursorId);
+    }
+
+    private BooleanExpression containsKeyword(String keyword) {
+        if (Objects.isNull(keyword)) {
+            return null;
+        }
+        return lecture.name.contains(keyword);
+    }
+
+    private BooleanExpression eqMajorType(String majorType) {
+        if (Objects.isNull(majorType)) {
+            return null;
+        }
+        return lecture.majorType.eq(majorType);
+    }
+
+    private BooleanExpression eqGrade(Integer grade) {
+        if (Objects.isNull(grade)) {
+            return null;
+        }
+        return lecture.lectureDetail.grade.eq(grade);
     }
 
     private OrderSpecifier<?> getOrderSpecifier(String orderOption) {

--- a/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureRepository.java
+++ b/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureRepository.java
@@ -1,15 +1,14 @@
 package usw.suwiki.domain.lecture.domain.repository;
 
 import java.util.Optional;
+import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 import usw.suwiki.domain.lecture.domain.Lecture;
 
-import javax.persistence.LockModeType;
-
 @Repository
-public interface LectureRepository extends JpaRepository<Lecture, Long>, LectureQueryRepository {
+public interface LectureRepository extends JpaRepository<Lecture, Long>, LectureCustomRepository {
     // TODO: 낙관적 락은 어떨지 고민해보기 (김영한님의 추천은 READ COMMITTED + 낙관적 락)
     @Lock(value = LockModeType.PESSIMISTIC_WRITE)
     // TODO: timeout 필요성 동시성 테스트로 확인하기

--- a/src/main/java/usw/suwiki/domain/lecture/service/LectureCRUDService.java
+++ b/src/main/java/usw/suwiki/domain/lecture/service/LectureCRUDService.java
@@ -1,17 +1,14 @@
 package usw.suwiki.domain.lecture.service;
 
-import static usw.suwiki.global.exception.ExceptionType.*;
+import static usw.suwiki.global.exception.ExceptionType.LECTURE_NOT_FOUND;
 
 import java.util.List;
-import java.util.Optional;
-
-import org.springframework.stereotype.Service;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import usw.suwiki.domain.lecture.controller.dto.LectureFindOption;
-import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
 import usw.suwiki.domain.lecture.domain.Lecture;
 import usw.suwiki.domain.lecture.domain.repository.LectureRepository;
+import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
 import usw.suwiki.global.exception.errortype.LectureException;
 
 @Service
@@ -19,11 +16,6 @@ import usw.suwiki.global.exception.errortype.LectureException;
 public class LectureCRUDService {
 
     private final LectureRepository lectureRepository;
-
-    public Lecture loadLectureFromId(Long id) {
-        Optional<Lecture> lecture = lectureRepository.findById(id);
-        return validateOptional(lecture);
-    }
 
     public List<String> loadMajorTypes() {
         List<String> majors = lectureRepository.findAllMajorType();
@@ -51,11 +43,4 @@ public class LectureCRUDService {
         return lectureRepository.findAllLectureByMajorType(option);
     }
 
-
-    public Lecture validateOptional(Optional<Lecture> lecture) {
-        if (lecture.isEmpty()) {
-            throw new LectureException(LECTURE_NOT_FOUND);
-        }
-        return lecture.get();
-    }
 }

--- a/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
+++ b/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
@@ -49,7 +49,6 @@ public class LectureService {
         return new LectureDetailResponseDto(lecture);
     }
 
-    // 강의 검색 - 시간표 생성시 조회
     public NoOffsetPaginationResponse<LectureWithScheduleResponse> findPagedLecturesWithSchedule(
             Long cursorId,
             int limit,

--- a/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
+++ b/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
@@ -1,26 +1,24 @@
 package usw.suwiki.domain.lecture.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import usw.suwiki.domain.lecture.controller.dto.LectureDetailResponseDto;
-import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
-import usw.suwiki.domain.lecture.controller.dto.LectureResponseDto;
 import usw.suwiki.domain.lecture.controller.dto.LectureAndCountResponseForm;
-import usw.suwiki.domain.lecture.domain.Lecture;
+import usw.suwiki.domain.lecture.controller.dto.LectureDetailResponseDto;
 import usw.suwiki.domain.lecture.controller.dto.LectureFindOption;
-
-import java.util.ArrayList;
-import java.util.List;
+import usw.suwiki.domain.lecture.controller.dto.LectureResponseDto;
+import usw.suwiki.domain.lecture.domain.Lecture;
+import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class LectureService {
 
     private final LectureCRUDService lectureCRUDService;
 
-    @Transactional(readOnly = true)
     public LectureAndCountResponseForm readLectureByKeyword(String keyword, LectureFindOption option) {
         if (option.passMajorFiltering()) {
             return readLectureByKeywordAndOption(keyword, option);
@@ -28,7 +26,6 @@ public class LectureService {
         return readLectureByKeywordAndMajor(keyword, option);
     }
 
-    @Transactional(readOnly = true)
     public LectureAndCountResponseForm readAllLecture(LectureFindOption option) {
         if (option.passMajorFiltering()) {
             return readAllLectureByOption(option);
@@ -36,11 +33,14 @@ public class LectureService {
         return readAllLectureByMajorType(option);
     }
 
-    @Transactional(readOnly = true)
     public LectureDetailResponseDto readLectureDetail(Long id) {
         Lecture lecture = lectureCRUDService.loadLectureFromId(id);
         return new LectureDetailResponseDto(lecture);
     }
+
+    // 강의 검색 - 시간표 생성시 조회
+
+
 
     private LectureAndCountResponseForm readLectureByKeywordAndOption(String keyword, LectureFindOption option) {
         LecturesAndCountDao lectureInfo = lectureCRUDService.loadLectureByKeywordAndOption(keyword, option);

--- a/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
+++ b/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
@@ -1,5 +1,7 @@
 package usw.suwiki.domain.lecture.service;
 
+import static usw.suwiki.global.exception.ExceptionType.LECTURE_NOT_FOUND;
+
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +12,9 @@ import usw.suwiki.domain.lecture.controller.dto.LectureDetailResponseDto;
 import usw.suwiki.domain.lecture.controller.dto.LectureFindOption;
 import usw.suwiki.domain.lecture.controller.dto.LectureResponseDto;
 import usw.suwiki.domain.lecture.domain.Lecture;
+import usw.suwiki.domain.lecture.domain.repository.LectureRepository;
 import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
+import usw.suwiki.global.exception.errortype.LectureException;
 
 @Service
 @Transactional(readOnly = true)
@@ -18,6 +22,7 @@ import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
 public class LectureService {
 
     private final LectureCRUDService lectureCRUDService;
+    private final LectureRepository lectureRepository;
 
     public LectureAndCountResponseForm readLectureByKeyword(String keyword, LectureFindOption option) {
         if (option.passMajorFiltering()) {
@@ -34,12 +39,19 @@ public class LectureService {
     }
 
     public LectureDetailResponseDto readLectureDetail(Long id) {
-        Lecture lecture = lectureCRUDService.loadLectureFromId(id);
+        Lecture lecture = findLectureById(id);
         return new LectureDetailResponseDto(lecture);
     }
 
     // 강의 검색 - 시간표 생성시 조회
 
+    /**
+     * 공통 메서드
+     */
+    public Lecture findLectureById(Long id) {
+        return lectureRepository.findById(id)
+                .orElseThrow(() -> new LectureException(LECTURE_NOT_FOUND));
+    }
 
 
     private LectureAndCountResponseForm readLectureByKeywordAndOption(String keyword, LectureFindOption option) {

--- a/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
+++ b/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
@@ -5,15 +5,21 @@ import static usw.suwiki.global.exception.ExceptionType.LECTURE_NOT_FOUND;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import usw.suwiki.domain.lecture.controller.dto.LectureAndCountResponseForm;
 import usw.suwiki.domain.lecture.controller.dto.LectureDetailResponseDto;
 import usw.suwiki.domain.lecture.controller.dto.LectureFindOption;
 import usw.suwiki.domain.lecture.controller.dto.LectureResponseDto;
+import usw.suwiki.domain.lecture.controller.dto.LectureWithScheduleResponse;
+import usw.suwiki.domain.lecture.controller.dto.OriginalLectureCellResponse;
 import usw.suwiki.domain.lecture.domain.Lecture;
 import usw.suwiki.domain.lecture.domain.repository.LectureRepository;
 import usw.suwiki.domain.lecture.domain.repository.dao.LecturesAndCountDao;
+import usw.suwiki.domain.lecture.util.LectureStringConverter;
+import usw.suwiki.domain.timetable.entity.TimetableCellSchedule;
+import usw.suwiki.global.dto.NoOffsetPaginationResponse;
 import usw.suwiki.global.exception.errortype.LectureException;
 
 @Service
@@ -44,6 +50,33 @@ public class LectureService {
     }
 
     // 강의 검색 - 시간표 생성시 조회
+    public NoOffsetPaginationResponse<LectureWithScheduleResponse> findPagedLecturesWithSchedule(
+            Long cursorId,
+            int limit,
+            String keyword,
+            String major,
+            Integer grade
+    ) {
+        Slice<Lecture> lectureSlice = lectureRepository
+                .findCurrentSemesterLectures(cursorId, limit, keyword, major, grade);
+
+        Slice<LectureWithScheduleResponse> result = lectureSlice
+                .map(this::convertLectureWithSchedule);
+
+        return NoOffsetPaginationResponse.of(result);
+    }
+
+    private LectureWithScheduleResponse convertLectureWithSchedule(Lecture lecture) {
+        LectureWithScheduleResponse response = LectureWithScheduleResponse.of(lecture);
+        String placeSchedule = lecture.getLectureDetail().getPlaceSchedule();
+
+        List<TimetableCellSchedule> scheduleList = LectureStringConverter
+                .convertScheduleChunkIntoTimetableCellScheduleList(placeSchedule);
+
+        scheduleList.forEach(it -> response.addOriginalCellResponse(OriginalLectureCellResponse.of(it)));
+        return response;
+    }
+
 
     /**
      * 공통 메서드

--- a/src/main/java/usw/suwiki/domain/lecture/util/LectureStringConverter.java
+++ b/src/main/java/usw/suwiki/domain/lecture/util/LectureStringConverter.java
@@ -1,0 +1,108 @@
+package usw.suwiki.domain.lecture.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import usw.suwiki.domain.timetable.entity.TimetableCellSchedule;
+import usw.suwiki.domain.timetable.entity.TimetableDay;
+
+public final class LectureStringConverter {
+    /**
+     * @param ScheduleChunk 강의의 장소 및 강의 시간 원본 (lecture.place_schedule)
+     * @implNote place_schedule을 TimetableCellSchedule 객체 리스트로 변환
+     */
+    public static List<TimetableCellSchedule> convertScheduleChunkIntoTimetableCellScheduleList(String ScheduleChunk) {
+        List<TimetableCellSchedule> scheduleList = new ArrayList<>();
+
+        if (Objects.equals(ScheduleChunk, "null")) {  // TODO refactor: "null" -> null. 데이터 파싱 로직 변경 필요
+            return scheduleList;
+        }
+
+        List<String> locationAndDaysChunkList = splitScheduleChunkIntoLocationAndDaysChunkList(ScheduleChunk);
+
+        for (String locationAndDaysChunk : locationAndDaysChunkList) {
+            String location = extractLocationFromLocationAndDaysChunk(locationAndDaysChunk);
+
+            String DaysChunk = extractDaysChunkFromLocationAndDaysElementChunk(locationAndDaysChunk);
+            for (String dayAndPeriodsChunk : splitDaysChunkIntoDayAndPeriodsChunkList(DaysChunk)) {
+
+                String day = dayAndPeriodsChunk.substring(0, 1);
+                String periodsChunk = dayAndPeriodsChunk.substring(1);
+
+                for (String connectedPeriods : splitUnconnectedPeriodsIntoConnectedPeriodsList(periodsChunk)) {
+                    List<Integer> periodList = convertStringListToIntList(connectedPeriods);
+                    Integer startPeriod = periodList.get(0);
+                    Integer endPeriod = periodList.get(periodList.size() - 1);
+
+                    TimetableCellSchedule schedule = TimetableCellSchedule.builder()
+                            .location(location)
+                            .day(TimetableDay.ofKorean(day))
+                            .startPeriod(startPeriod)
+                            .endPeriod(endPeriod)
+                            .build();
+                    scheduleList.add(schedule);
+                }
+            }
+        }
+        return scheduleList;
+    }
+
+
+    private static List<String> splitScheduleChunkIntoLocationAndDaysChunkList(String chunk) {
+        // e.g. "IT103(..),IT505(..)" -> [ "IT103(..)", "IT505(..)" ]
+        return Arrays.asList(chunk.split(",(?![^()]*\\))"));
+    }
+
+    private static String extractLocationFromLocationAndDaysChunk(String chunk) {
+        // e.g. "IT103(월1,2, 화1,2)" -> "IT103"
+        return chunk.split("\\(")[0];
+    }
+
+    private static String extractDaysChunkFromLocationAndDaysElementChunk(String chunk) {
+        // e.g. IT103(월1,2, 화1,2) -> "월1,2, 화1,2"
+        int start = chunk.indexOf('(') + 1, end = chunk.lastIndexOf(')');
+        return chunk.substring(start, end);
+    }
+
+    private static List<String> splitDaysChunkIntoDayAndPeriodsChunkList(String chunk) {
+        // e.g. "월1,2, 화1,2" -> [ "월1,2", "화1,2" ]
+        return Arrays.asList(chunk.split(" "));
+    }
+
+    private static List<String> splitUnconnectedPeriodsIntoConnectedPeriodsList(String unconnectedPeriods) {
+        // e.g. "1,2,3,5,6,7,9,10" -> [ "1,2,3", "5,6,7", "9,10" ]
+        String[] numbers = unconnectedPeriods.split(",");
+        Arrays.sort(numbers);
+
+        List<String> connectedPeriodsList = new ArrayList<>();
+        List<String> currentGroup = new ArrayList<>();
+
+        for (String number : numbers) {
+            int num = Integer.parseInt(number);
+
+            if (currentGroup.isEmpty() || num == Integer.parseInt(currentGroup.get(currentGroup.size() - 1)) + 1) {
+                currentGroup.add(number);
+            } else {
+                connectedPeriodsList.add(String.join(",", currentGroup));
+                currentGroup.clear();
+                currentGroup.add(number);
+            }
+        }
+
+        if (!currentGroup.isEmpty()) {
+            connectedPeriodsList.add(String.join(",", currentGroup));
+        }
+
+        return connectedPeriodsList;
+    }
+
+    private static List<Integer> convertStringListToIntList(String stringList) {
+        String[] elements = stringList.split(",");
+
+        return Arrays.stream(elements)
+                .map(Integer::parseInt)
+                .toList();
+    }
+
+}

--- a/src/main/java/usw/suwiki/domain/lecture/util/LectureStringConverter.java
+++ b/src/main/java/usw/suwiki/domain/lecture/util/LectureStringConverter.java
@@ -4,20 +4,32 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import usw.suwiki.domain.timetable.entity.TimetableCellSchedule;
 import usw.suwiki.domain.timetable.entity.TimetableDay;
 
+// TODO refactor: TimetableCellSchedule 의존성 제거. 해당 클래스는 스트링 변환 작업만 책임지도록
 public final class LectureStringConverter {
-    // TODO refactor: TimetableCellSchedule 의존성 제거. 해당 클래스는 스트링 변환 작업만 책임지도록
+
+    /*
+        변환에 필요한 최소한의 스트링 형식입니다.    https://regexr.com/7q2nv
+        pass : "강의실107-1(수6,7,8)" "강의실 B215(화5,6,7 수5,6,7)"
+        fail : "(월1,2)" "강의실(1,2)" "강의실 월1,2" "강의실107(요일아님6,7,8)"
+     */
+    private static final String PLACE_SCHEDULE_REGEX = "^([\\s가-힣A-Za-z\\d-]+\\([월화수목금토일]\\d+(?:,\\d+)*.*?\\))+$";
+
     /**
-     * @param scheduleChunk 강의의 장소 및 강의 시간 원본 (lecture.place_schedule)
+     * @param scheduleChunk 강의 장소 및 시간 원본 lecture.place_schedule
      * @implNote place_schedule을 TimetableCellSchedule 객체 리스트로 변환
      */
     public static List<TimetableCellSchedule> convertScheduleChunkIntoTimetableCellScheduleList(String scheduleChunk) {
         List<TimetableCellSchedule> scheduleList = new ArrayList<>();
 
         // TODO refactor: "null" -> null. 데이터 파싱 로직 변경 필요
-        if (Objects.equals(scheduleChunk, "null") || Objects.isNull(scheduleChunk)) {
+        if (Objects.equals(scheduleChunk, "null")
+                || Objects.isNull(scheduleChunk)
+                || !Pattern.matches(PLACE_SCHEDULE_REGEX, scheduleChunk)
+        ) {
             return scheduleList;
         }
 

--- a/src/main/java/usw/suwiki/domain/lecture/util/LectureStringConverter.java
+++ b/src/main/java/usw/suwiki/domain/lecture/util/LectureStringConverter.java
@@ -8,18 +8,20 @@ import usw.suwiki.domain.timetable.entity.TimetableCellSchedule;
 import usw.suwiki.domain.timetable.entity.TimetableDay;
 
 public final class LectureStringConverter {
+    // TODO refactor: TimetableCellSchedule 의존성 제거. 해당 클래스는 스트링 변환 작업만 책임지도록
     /**
-     * @param ScheduleChunk 강의의 장소 및 강의 시간 원본 (lecture.place_schedule)
+     * @param scheduleChunk 강의의 장소 및 강의 시간 원본 (lecture.place_schedule)
      * @implNote place_schedule을 TimetableCellSchedule 객체 리스트로 변환
      */
-    public static List<TimetableCellSchedule> convertScheduleChunkIntoTimetableCellScheduleList(String ScheduleChunk) {
+    public static List<TimetableCellSchedule> convertScheduleChunkIntoTimetableCellScheduleList(String scheduleChunk) {
         List<TimetableCellSchedule> scheduleList = new ArrayList<>();
 
-        if (Objects.equals(ScheduleChunk, "null")) {  // TODO refactor: "null" -> null. 데이터 파싱 로직 변경 필요
+        // TODO refactor: "null" -> null. 데이터 파싱 로직 변경 필요
+        if (Objects.equals(scheduleChunk, "null") || Objects.isNull(scheduleChunk)) {
             return scheduleList;
         }
 
-        List<String> locationAndDaysChunkList = splitScheduleChunkIntoLocationAndDaysChunkList(ScheduleChunk);
+        List<String> locationAndDaysChunkList = splitScheduleChunkIntoLocationAndDaysChunkList(scheduleChunk);
 
         for (String locationAndDaysChunk : locationAndDaysChunkList) {
             String location = extractLocationFromLocationAndDaysChunk(locationAndDaysChunk);

--- a/src/main/java/usw/suwiki/domain/timetable/entity/TimetableDay.java
+++ b/src/main/java/usw/suwiki/domain/timetable/entity/TimetableDay.java
@@ -8,8 +8,14 @@ import usw.suwiki.global.util.enums.KeyValueEnumModel;
 
 @RequiredArgsConstructor
 public enum TimetableDay implements KeyValueEnumModel<String> {
-    MON("MON"), TUE("TUE"), WED("WED"), THU("THU"), FRI("FRI"), SAT("SAT"), E_LEARNING("E_LEARNING")
-    ;
+    MON("MON"),
+    TUE("TUE"),
+    WED("WED"),
+    THU("THU"),
+    FRI("FRI"),
+    SAT("SAT"),
+    SUN("SUN"),
+    E_LEARNING("E_LEARNING");
 
     private final String value;
 

--- a/src/main/java/usw/suwiki/domain/timetable/entity/TimetableDay.java
+++ b/src/main/java/usw/suwiki/domain/timetable/entity/TimetableDay.java
@@ -26,6 +26,20 @@ public enum TimetableDay implements KeyValueEnumModel<String> {
                 .orElseThrow(() -> new TimetableException(ExceptionType.INVALID_TIMETABLE_CELL_DAY));
     }
 
+    public static TimetableDay ofKorean(String param) {
+        return switch (param) {
+            case "월" -> MON;
+            case "화" -> TUE;
+            case "수" -> WED;
+            case "목" -> THU;
+            case "금" -> FRI;
+            case "토" -> SAT;
+            case "일" -> SUN;
+
+            default -> throw new TimetableException(ExceptionType.INVALID_TIMETABLE_CELL_DAY);
+        };
+    }
+
     @Override
     public String getKey() {
         return this.name();

--- a/src/main/java/usw/suwiki/global/dto/ApiResponse.java
+++ b/src/main/java/usw/suwiki/global/dto/ApiResponse.java
@@ -31,8 +31,6 @@ public class ApiResponse<T> {
 
     public static ApiResponse error(String code, String message) {
         HashMap<String, String> empty = new HashMap<>();
-        System.out.println("code = " + code);
-        System.out.println("message = " + message);
         return ApiResponse.builder()
                 .code(code)
                 .data(empty)

--- a/src/main/java/usw/suwiki/global/dto/NoOffsetPaginationResponse.java
+++ b/src/main/java/usw/suwiki/global/dto/NoOffsetPaginationResponse.java
@@ -1,0 +1,31 @@
+package usw.suwiki.global.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class NoOffsetPaginationResponse<T> {
+    Boolean isLast;
+    List<T> content;
+
+    public static <T> NoOffsetPaginationResponse<T> of(Slice<T> slice) {
+        return NoOffsetPaginationResponse.<T>builder()
+                .content(slice.getContent())
+                .isLast(slice.isLast())
+                .build();
+    }
+
+    public static <T> NoOffsetPaginationResponse<T> of(Page<T> page) {
+        return NoOffsetPaginationResponse.<T>builder()
+                .content(page.getContent())
+                .isLast(page.isLast())
+                .build();
+    }
+}

--- a/src/main/java/usw/suwiki/global/exception/ExceptionType.java
+++ b/src/main/java/usw/suwiki/global/exception/ExceptionType.java
@@ -79,6 +79,7 @@ public enum ExceptionType {
     NOT_EXISTS_LECTURE_NAME("LECTURE001", "강의 제목을 입력해주세요", BAD_REQUEST),
     NOT_EXISTS_PROFESSOR_NAME("LECTURE002", "교수 이름을 입력해주세요", BAD_REQUEST),
     NOT_EXISTS_LECTURE("LECTURE003", "해당 강의가 존재하지 않습니다.", BAD_REQUEST),
+    INVALID_LECTURE_PLACE_SCHEDULE_FORM("LECTURE101", "유효하지 않은 강의의 장소 및 교시입니다.", INTERNAL_SERVER_ERROR),
     //404
     LECTURE_NOT_FOUND("LECTURE001", "해당 강의에 대한 정보를 찾을 수 없습니다.", NOT_FOUND),
 

--- a/src/main/java/usw/suwiki/global/jwt/JwtAgent.java
+++ b/src/main/java/usw/suwiki/global/jwt/JwtAgent.java
@@ -178,17 +178,10 @@ public class JwtAgent {
                 .atZone(ZoneId.systemDefault())
                 .toLocalDateTime();
 
-        System.out.println("tokenExpiredAt = " + tokenExpiredAt);
-        System.out.println("LocalDateTime.now() = " + LocalDateTime.now());
-
         // 만료 시간 > 현재 시간 => 정상
 
         // 현재시간 - 7일(초단위) 를 한 피연산자 할당
         LocalDateTime subDetractedDateTime = LocalDateTime.now().plusSeconds(604800);
-        System.out.println("subDetractedDateTime = " + subDetractedDateTime);
-
-        System.out.println(
-                "tokenExpiredAt.isBefore(subDetractedDateTime) = " + tokenExpiredAt.isBefore(subDetractedDateTime));
         // 피연산자 보다 이전 이면 True 반환 및 갱신해줘야함
         return tokenExpiredAt.isBefore(LocalDateTime.now());
     }

--- a/src/main/java/usw/suwiki/global/util/query/SlicePaginationUtils.java
+++ b/src/main/java/usw/suwiki/global/util/query/SlicePaginationUtils.java
@@ -1,0 +1,25 @@
+package usw.suwiki.global.util.query;
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+public class SlicePaginationUtils {
+    public static final int SLICE_LIMIT_PLUS_AMOUNT = 1;
+
+    public static <T> Slice<T> buildSlice(List<T> content, int size) {
+        boolean hasNext = false;
+
+        if (content.size() > size) {
+            content.remove(size);
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(content, Pageable.ofSize(size), hasNext);
+    }
+
+    public static int increaseSliceLimit(int size) {
+        return size + SLICE_LIMIT_PLUS_AMOUNT;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,6 @@ logging:
   level:
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+business:
+  current-semester: 2023-2

--- a/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
@@ -111,7 +111,7 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 ë³
             ));
         }
 
-        Slice<Lecture> result = lectureRepository.findCurrentSemesterLecturesPage(
+        Slice<Lecture> result = lectureRepository.findCurrentSemesterLectures(
                 0L,
                 20,
                 null, null, null
@@ -176,28 +176,28 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 ë³
 
         // TODO fix: Slice 0 containing UNKNOWN instances
         // when
-        Slice<Lecture> currentSemester = lectureRepository.findCurrentSemesterLecturesPage(
+        Slice<Lecture> currentSemester = lectureRepository.findCurrentSemesterLectures(
                 cursorId,
                 limit,
                 null,
                 null,
                 null
         );
-        Slice<Lecture> keywordResult = lectureRepository.findCurrentSemesterLecturesPage(
+        Slice<Lecture> keywordResult = lectureRepository.findCurrentSemesterLectures(
                 cursorId,
                 limit,
                 keyword,
                 null,
                 null
         );
-        Slice<Lecture> majorResult = lectureRepository.findCurrentSemesterLecturesPage(
+        Slice<Lecture> majorResult = lectureRepository.findCurrentSemesterLectures(
                 cursorId,
                 limit,
                 null,
                 majorType,
                 null
         );
-        Slice<Lecture> majorGradeResult = lectureRepository.findCurrentSemesterLecturesPage(
+        Slice<Lecture> majorGradeResult = lectureRepository.findCurrentSemesterLectures(
                 cursorId,
                 limit,
                 null,

--- a/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
@@ -30,6 +30,7 @@ import usw.suwiki.template.lecture.LectureTemplate;
 import usw.suwiki.template.user.UserTemplate;
 
 // TODO: RepositoryTest 슈퍼 클래스로 공통 설정 상속
+// TODO refactor: 테스트 독립성 보장. TRUNCATE 실행
 @DataJpaTest
 @Import(TestJpaConfig.class)
 @TestMethodOrder(MethodOrderer.DisplayName.class)

--- a/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
@@ -50,7 +50,7 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 �
     }
 
     @Test
-    @DisplayName("Lecture 단일 조회 성공")
+    @DisplayName("강의 단일 조회")
     public void selectLecture_success() {
         // given
         Long id = dummyLecture.getId();
@@ -67,7 +67,7 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 �
     }
 
     @Test
-    @DisplayName("Lecture 단일 조회 성공 - 비관적 락 조회")
+    @DisplayName("강의 단일 조회 - 비관적 락")
     public void selectLecture_success_with_pessimistic_lock() {
         // given
         Long id = dummyLecture.getId();

--- a/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
@@ -5,17 +5,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Optional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Slice;
 import usw.suwiki.config.TestJpaConfig;
 import usw.suwiki.domain.evaluatepost.domain.EvaluatePost;
 import usw.suwiki.domain.lecture.domain.Lecture;
+import usw.suwiki.domain.lecture.domain.LectureDetail;
 import usw.suwiki.domain.lecture.domain.repository.LectureRepository;
 import usw.suwiki.domain.user.user.User;
 import usw.suwiki.domain.user.user.repository.UserRepository;
@@ -23,9 +29,11 @@ import usw.suwiki.template.evaluatepost.EvaluatePostTemplate;
 import usw.suwiki.template.lecture.LectureTemplate;
 import usw.suwiki.template.user.UserTemplate;
 
+// TODO: RepositoryTest 슈퍼 클래스로 공통 설정 상속
 @DataJpaTest
 @Import(TestJpaConfig.class)
 @TestMethodOrder(MethodOrderer.DisplayName.class)
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 보면서 동시성 테스트하는 방법 공부
     @Autowired
     private LectureRepository lectureRepository;
@@ -40,11 +48,83 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 �
     private Lecture dummyLecture;
     private EvaluatePost dummyEvaluatePost;
 
+    @Value("${business.current-semester}")
+    private String currentSemester;
+
     @BeforeEach
     void setUp() {
         this.dummyUser = userRepository.save(UserTemplate.createDummyUser());
         this.dummyLecture = lectureRepository.save(LectureTemplate.createFirstDummyLecture());
         this.dummyEvaluatePost = EvaluatePostTemplate.createFirstDummyEvaluatePost(dummyUser, dummyLecture);
+
+        LectureDetail firstGradeLectureDetail = LectureDetail.builder()
+                .grade(1)
+                .evaluateType("상대평가")
+                .point(2.0)
+                .build();
+        LectureDetail secondGradeLectureDetail = LectureDetail.builder()
+                .grade(2)
+                .evaluateType("상대평가")
+                .point(2.0)
+                .build();
+
+        /*  테스트 시나리오 (강의 리스트 조회 - 시간표상 이번 학기에 열린 강의 리스트 조회)
+
+            총 과목 개수는 21개
+            semester: 이번 학기인 과목은 80개
+            name: 이번 학기중 "도전과 창조"가 포함된 과목은 60개
+            major: 이번 학기중 "교양"인 과목은 40개, "교양(야)"인 과목은 10개
+            grade: 이번 학기중 2학년 과목은 20개
+         */
+        for (int i = 0; i < 20; i++) {
+            lectureRepository.save(LectureTemplate.createDummyLecture(
+                    "2021-2, 2022-2, " + currentSemester,
+                    "도전과 창조",
+                    "중핵",
+                    "교양 아님",
+                    "우문균",
+                    firstGradeLectureDetail
+            ));
+            lectureRepository.save(LectureTemplate.createDummyLecture(
+                    "2021-2, 2022-2, " + currentSemester,
+                    "테스트학개론",
+                    "중핵",
+                    "교양 아님",
+                    "우문균",
+                    firstGradeLectureDetail
+            ));
+            lectureRepository.save(LectureTemplate.createDummyLecture(
+                    "2021-2, 2022-2, " + currentSemester,
+                    "도전과 창조",
+                    "중핵",
+                    "교양",
+                    "우문균",
+                    firstGradeLectureDetail
+            ));
+            lectureRepository.save(LectureTemplate.createDummyLecture(
+                    "2021-2, 2022-2, " + currentSemester,
+                    "도전과 창조",
+                    "중핵",
+                    "교양",
+                    "우문균",
+                    secondGradeLectureDetail
+            ));
+        }
+
+        Slice<Lecture> result = lectureRepository.findCurrentSemesterLecturesPage(
+                0L,
+                20,
+                null, null, null
+        );
+        System.out.println("result = " + result);
+
+        entityManager.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+        lectureRepository.deleteAll();
 
         entityManager.clear();
     }
@@ -81,5 +161,54 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 �
                 .isEqualTo(dummyLecture.getName());
         assertThat(foundLecture.get().getLectureDetail().getCode())
                 .isEqualTo(dummyLecture.getLectureDetail().getCode());
+    }
+
+    @Test
+    @DisplayName("시간표 강의 리스트 조회 - 이번 학기에 열린 강의 리스트 조회")
+    public void selectTimetableLectureList_success() {
+        // given
+        long cursorId = 0;
+        int limit = 80;
+        String keyword = "도전";
+        String majorType = "교양";
+        int grade = 2;
+        System.out.println("lectureRepository.count() = " + lectureRepository.count());
+
+        // TODO fix: Slice 0 containing UNKNOWN instances
+        // when
+        Slice<Lecture> currentSemester = lectureRepository.findCurrentSemesterLecturesPage(
+                cursorId,
+                limit,
+                null,
+                null,
+                null
+        );
+        Slice<Lecture> keywordResult = lectureRepository.findCurrentSemesterLecturesPage(
+                cursorId,
+                limit,
+                keyword,
+                null,
+                null
+        );
+        Slice<Lecture> majorResult = lectureRepository.findCurrentSemesterLecturesPage(
+                cursorId,
+                limit,
+                null,
+                majorType,
+                null
+        );
+        Slice<Lecture> majorGradeResult = lectureRepository.findCurrentSemesterLecturesPage(
+                cursorId,
+                limit,
+                null,
+                majorType,
+                grade
+        );
+
+        // then
+        assertThat(currentSemester.getContent().size()).isEqualTo(80);
+        assertThat(keywordResult.getContent().size()).isEqualTo(60);
+        assertThat(majorResult.getContent().size()).isEqualTo(40);
+        assertThat(majorGradeResult.getContent().size()).isEqualTo(20);
     }
 }

--- a/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
@@ -117,8 +117,6 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 �
                 20,
                 null, null, null
         );
-        System.out.println("result = " + result);
-
         entityManager.clear();
     }
 
@@ -173,7 +171,6 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 �
         String keyword = "도전";
         String majorType = "교양";
         int grade = 2;
-        System.out.println("lectureRepository.count() = " + lectureRepository.count());
 
         // TODO fix: Slice 0 containing UNKNOWN instances
         // when

--- a/src/test/java/usw/suwiki/service/lecture/LectureServiceTest.java
+++ b/src/test/java/usw/suwiki/service/lecture/LectureServiceTest.java
@@ -1,0 +1,108 @@
+package usw.suwiki.service.lecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import usw.suwiki.domain.lecture.controller.dto.LectureWithScheduleResponse;
+import usw.suwiki.domain.lecture.domain.Lecture;
+import usw.suwiki.domain.lecture.domain.repository.LectureRepository;
+import usw.suwiki.domain.lecture.service.LectureService;
+import usw.suwiki.global.dto.NoOffsetPaginationResponse;
+import usw.suwiki.template.lecture.LectureDetailTemplate;
+import usw.suwiki.template.lecture.LectureTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@TestMethodOrder(MethodOrderer.DisplayName.class)
+public class LectureServiceTest {
+    @InjectMocks
+    LectureService lectureService;
+
+    @Mock
+    LectureRepository lectureRepository;
+
+    @Value("${business.current-semester}")
+    private String currentSemester;
+
+    public static final long SPYING_ID = 123712L;
+
+    @Test
+    @DisplayName("시간표 생성시 강의 검색 - 이번 학기에 열린 강의 리스트 조회")
+    public void SELECT_LECTURE_LIST_TIMETABLE_THIS_SEMESTER() {
+        // given
+        Lecture multipleLocationLecture = spy(LectureTemplate.createDummyLecture(
+                currentSemester,
+                "물리학및실험2",
+                "전교",
+                "전자재료공학부",
+                "전계진",
+                LectureDetailTemplate.varyPlaceSchedule("미래103(화1,2),미래B102(화3,4)")     // 스케줄 2개
+        ));
+        Lecture multipleDayLecture = spy(LectureTemplate.createDummyLecture(
+                currentSemester,
+                "관현악합주6",
+                "전핵",
+                "관현악과",
+                "박태영",
+                LectureDetailTemplate.varyPlaceSchedule("음악109(월5,6 화5,6 수5,6)")        // 스케줄 3개
+        ));
+        Lecture multipleLocationAndDayLecture = spy(LectureTemplate.createDummyLecture(
+                currentSemester,
+                "역대급헬강의",
+                "전핵",
+                "역대급학부",
+                "역대급교수",
+                LectureDetailTemplate.varyPlaceSchedule("미래103(월1,2 화1,2),미래B102(월7,8 화7,8)")   // 스케줄 4개
+        ));
+        Lecture unconnectedPeriodsLecture = spy(LectureTemplate.createDummyLecture(
+                currentSemester,
+                "건축설계2",
+                "전핵",
+                "건축학",
+                "최기원",
+                LectureDetailTemplate.varyPlaceSchedule("2공학207(목1,2,3,5,6,7)")     // 스케줄 2개
+        ));
+
+        List<Lecture> lectureList = List.of(
+                multipleLocationLecture,
+                multipleDayLecture,
+                multipleLocationAndDayLecture,
+                unconnectedPeriodsLecture
+        );
+        Slice<Lecture> queryResult = new SliceImpl<>(lectureList);
+        given(lectureRepository.findCurrentSemesterLectures(anyLong(), anyInt(), any(), any(), any()))
+                .willReturn(queryResult);
+
+        when(multipleLocationLecture.getId()).thenReturn(SPYING_ID);
+        when(multipleDayLecture.getId()).thenReturn(SPYING_ID);
+        when(multipleLocationAndDayLecture.getId()).thenReturn(SPYING_ID);
+        when(unconnectedPeriodsLecture.getId()).thenReturn(SPYING_ID);
+
+        // when
+        NoOffsetPaginationResponse<LectureWithScheduleResponse> response = lectureService
+                .findPagedLecturesWithSchedule(0L, 20, null, null, null);
+
+        // then
+        assertThat(response.getIsLast()).isTrue();
+        assertThat(response.getContent().get(0).getOriginalCellList().size()).isEqualTo(2);
+        assertThat(response.getContent().get(1).getOriginalCellList().size()).isEqualTo(3);
+        assertThat(response.getContent().get(2).getOriginalCellList().size()).isEqualTo(4);
+        assertThat(response.getContent().get(3).getOriginalCellList().size()).isEqualTo(2);
+    }
+}

--- a/src/test/java/usw/suwiki/template/lecture/LectureDetailTemplate.java
+++ b/src/test/java/usw/suwiki/template/lecture/LectureDetailTemplate.java
@@ -11,11 +11,15 @@ public class LectureDetailTemplate {
     public static final int GRADE = 2;
     public static final String EVALUATE_TYPE = "상대평가";
 
-    public static LectureDetail createfirstDummyLectureDetail() {
-        return createDummyLectureDetail(PLACE_SCHEDULE, CODE, POINT, CAPPR_TYPE, DICL_NO, GRADE, EVALUATE_TYPE);
+    public static LectureDetail createFirstDummy() {
+        return createDummy(PLACE_SCHEDULE, CODE, POINT, CAPPR_TYPE, DICL_NO, GRADE, EVALUATE_TYPE);
     }
 
-    public static LectureDetail createDummyLectureDetail(
+    public static LectureDetail varyPlaceSchedule(String placeSchedule) {
+        return createDummy(placeSchedule, CODE, POINT, CAPPR_TYPE, DICL_NO, GRADE, EVALUATE_TYPE);
+    }
+
+    public static LectureDetail createDummy(
             String placeSchedule,
             String code,
             double point,

--- a/src/test/java/usw/suwiki/template/lecture/LectureTemplate.java
+++ b/src/test/java/usw/suwiki/template/lecture/LectureTemplate.java
@@ -4,7 +4,7 @@ import usw.suwiki.domain.lecture.domain.Lecture;
 import usw.suwiki.domain.lecture.domain.LectureDetail;
 
 public class LectureTemplate {
-    public static final String SEMESTER = "2022-2, 2023-2";
+    public static final String SEMESTER = "2022-1, 2023-1";
     public static final String PROFESSOR = "신호진";
     public static final String NAME = "데이터 구조";
     public static final String MAJOR_TYPE = "컴퓨터 학부";
@@ -17,18 +17,18 @@ public class LectureTemplate {
 
     public static Lecture createDummyLecture(
             String semester,
-            String professor,
             String name,
-            String majorType,
             String type,
+            String majorType,
+            String professor,
             LectureDetail lectureDetail
     ) {
         return Lecture.builder()
                 .semester(semester)
-                .professor(professor)
                 .name(name)
-                .majorType(majorType)
                 .type(type)
+                .majorType(majorType)
+                .professor(professor)
                 .lectureDetail(lectureDetail)
                 .build();
     }

--- a/src/test/java/usw/suwiki/template/lecture/LectureTemplate.java
+++ b/src/test/java/usw/suwiki/template/lecture/LectureTemplate.java
@@ -9,7 +9,7 @@ public class LectureTemplate {
     public static final String NAME = "데이터 구조";
     public static final String MAJOR_TYPE = "컴퓨터 학부";
     public static final String LECTURE_TYPE = "전핵";
-    public static final LectureDetail LECTURE_DETAIL = LectureDetailTemplate.createfirstDummyLectureDetail();
+    public static final LectureDetail LECTURE_DETAIL = LectureDetailTemplate.createFirstDummy();
 
     public static Lecture createFirstDummyLecture() {
         return createDummyLecture(SEMESTER, PROFESSOR, NAME, MAJOR_TYPE, LECTURE_TYPE, LECTURE_DETAIL);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,24 @@
+spring:
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test;MODE=MySQL
+    username: sa
+    password:
+
+  jpa:
+    database: h2
+    generate-ddl: true
+    open-in-view: false
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      dialect: org.hibernate.dialect.MySQL57InnoDBDialect
+      hibernate:
+        format_sql: true
+# SQL 예약어 예외 방지 (user, year)
+        globally_quoted_identifiers: true
+        globally_quoted_identifiers_skip_column_definitions : true
+
+business:
+  current-semester: 2023-2


### PR DESCRIPTION
## 🙋 어떤 PR인가요?
시간표 생성에 사용되는 현재 학기 강의 검색입니다.
시간표 셀로 변환될 수 있도록 데이터 가공하는 로직을 추가했습니다. (lecture.place_schedule -> TimetableCellSchedule)

## 📝 작업 상세
- 강의 데이터 변환 로직
- LectureRepository
- LectureRepositoryTest
- LectureService : 강의 검색
- LectureServiceTest : 강의 데이터 경우의 수에 따른 오류 검증 
- LectureController

## 🙏 To Reviewers
이제 application.yml 파일은 gitignore에서 해제됐습니다. 
프로파일 모두에 공통적으로 사용되는 프로퍼티는 해당 파일에서 관리하겠습니다.

## 🧐 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
- [x]  정상동작하는지, 테스트 통과하는지 다시 한번 확인해주세요.
