### PR TITLE
fix : 메일 인증 링크 프로퍼티 객체 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,10 @@ dependencies {
     implementation 'org.modelmapper:modelmapper:3.1.1'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    // configuration
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
 }
 
 test {

--- a/src/main/java/usw/suwiki/SuwikiApplication.java
+++ b/src/main/java/usw/suwiki/SuwikiApplication.java
@@ -2,14 +2,17 @@ package usw.suwiki;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import usw.suwiki.global.properties.ServerProperties;
 
 @SpringBootApplication
 @EnableScheduling
 @EnableJpaAuditing
 @EnableCaching
+@EnableConfigurationProperties(value = {ServerProperties.class})
 public class SuwikiApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/usw/suwiki/domain/user/user/service/UserBusinessService.java
+++ b/src/main/java/usw/suwiki/domain/user/user/service/UserBusinessService.java
@@ -50,6 +50,7 @@ import usw.suwiki.domain.userlecture.viewexam.service.ViewExamCRUDService;
 import usw.suwiki.global.ResponseForm;
 import usw.suwiki.global.exception.errortype.AccountException;
 import usw.suwiki.global.jwt.JwtAgent;
+import usw.suwiki.global.properties.ServerProperties;
 import usw.suwiki.global.util.emailBuild.BuildEmailAuthForm;
 import usw.suwiki.global.util.emailBuild.BuildFindLoginIdForm;
 import usw.suwiki.global.util.emailBuild.BuildFindPasswordForm;
@@ -59,10 +60,10 @@ import usw.suwiki.global.util.mailsender.EmailSender;
 @RequiredArgsConstructor
 @Transactional
 public class UserBusinessService {
-
-    private static final String BASE_LINK = "https://api.suwiki.kr/v2/confirmation-token/verify/?token=";
-    private static final String LOCAL_BASE_LINK = "http://localhost:8080/v2/confirmation-token/verify/?token=";
+    private static final String CONFIRMATION_TOKEN_URL = "/v2/confirmation-token/verify/?token=";
     private static final String MAIL_FORM = "@suwon.ac.kr";
+
+    private final ServerProperties serverProperties;
     private final UserCRUDService userCRUDService;
     private final UserIsolationCRUDService userIsolationCRUDService;
     private final ConfirmationTokenCRUDService confirmationTokenCRUDService;
@@ -122,7 +123,9 @@ public class UserBusinessService {
 
         emailSender.send(
                 email,
-                buildEmailAuthForm.buildEmail(BASE_LINK + confirmationToken.getToken())
+                buildEmailAuthForm.buildEmail(
+                        serverProperties.getDomain() + CONFIRMATION_TOKEN_URL + confirmationToken.getToken()
+                )
         );
         return successFlag();
     }

--- a/src/main/java/usw/suwiki/domain/user/user/service/UserBusinessService.java
+++ b/src/main/java/usw/suwiki/domain/user/user/service/UserBusinessService.java
@@ -50,7 +50,6 @@ import usw.suwiki.domain.userlecture.viewexam.service.ViewExamCRUDService;
 import usw.suwiki.global.ResponseForm;
 import usw.suwiki.global.exception.errortype.AccountException;
 import usw.suwiki.global.jwt.JwtAgent;
-import usw.suwiki.global.properties.ServerProperties;
 import usw.suwiki.global.util.emailBuild.BuildEmailAuthForm;
 import usw.suwiki.global.util.emailBuild.BuildFindLoginIdForm;
 import usw.suwiki.global.util.emailBuild.BuildFindPasswordForm;
@@ -60,10 +59,8 @@ import usw.suwiki.global.util.mailsender.EmailSender;
 @RequiredArgsConstructor
 @Transactional
 public class UserBusinessService {
-    private static final String CONFIRMATION_TOKEN_URL = "/v2/confirmation-token/verify/?token=";
     private static final String MAIL_FORM = "@suwon.ac.kr";
 
-    private final ServerProperties serverProperties;
     private final UserCRUDService userCRUDService;
     private final UserIsolationCRUDService userIsolationCRUDService;
     private final ConfirmationTokenCRUDService confirmationTokenCRUDService;
@@ -121,12 +118,7 @@ public class UserBusinessService {
         ConfirmationToken confirmationToken = ConfirmationToken.makeToken(user);
         confirmationTokenCRUDService.saveConfirmationToken(confirmationToken);
 
-        emailSender.send(
-                email,
-                buildEmailAuthForm.buildEmail(
-                        serverProperties.getDomain() + CONFIRMATION_TOKEN_URL + confirmationToken.getToken()
-                )
-        );
+        emailSender.send(email, buildEmailAuthForm.buildEmail(confirmationToken));
         return successFlag();
     }
 

--- a/src/main/java/usw/suwiki/domain/user/user/service/UserBusinessService.java
+++ b/src/main/java/usw/suwiki/domain/user/user/service/UserBusinessService.java
@@ -1,5 +1,25 @@
 package usw.suwiki.domain.user.user.service;
 
+import static usw.suwiki.domain.postreport.EvaluatePostReport.buildEvaluatePostReport;
+import static usw.suwiki.domain.postreport.ExamPostReport.buildExamPostReport;
+import static usw.suwiki.domain.user.user.controller.dto.UserResponseDto.UserInformationResponseForm.buildMyPageResponseForm;
+import static usw.suwiki.global.exception.ExceptionType.IS_NOT_EMAIL_FORM;
+import static usw.suwiki.global.exception.ExceptionType.LOGIN_ID_OR_EMAIL_OVERLAP;
+import static usw.suwiki.global.exception.ExceptionType.PASSWORD_ERROR;
+import static usw.suwiki.global.exception.ExceptionType.PASSWORD_NOT_CHANGED;
+import static usw.suwiki.global.exception.ExceptionType.USER_NOT_EXISTS;
+import static usw.suwiki.global.exception.ExceptionType.USER_NOT_FOUND_BY_EMAIL;
+import static usw.suwiki.global.exception.ExceptionType.USER_NOT_FOUND_BY_LOGINID;
+import static usw.suwiki.global.exception.ExceptionType.USER_RESTRICTED;
+import static usw.suwiki.global.util.apiresponse.ApiResponseFactory.overlapFalseFlag;
+import static usw.suwiki.global.util.apiresponse.ApiResponseFactory.overlapTrueFlag;
+import static usw.suwiki.global.util.apiresponse.ApiResponseFactory.successFlag;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -12,7 +32,6 @@ import usw.suwiki.domain.evaluatepost.domain.EvaluatePost;
 import usw.suwiki.domain.evaluatepost.service.EvaluatePostCRUDService;
 import usw.suwiki.domain.exampost.domain.ExamPost;
 import usw.suwiki.domain.exampost.service.ExamPostCRUDService;
-import usw.suwiki.domain.userlecture.viewexam.service.ViewExamCRUDService;
 import usw.suwiki.domain.favoritemajor.dto.FavoriteSaveDto;
 import usw.suwiki.domain.favoritemajor.service.FavoriteMajorService;
 import usw.suwiki.domain.postreport.service.ReportPostService;
@@ -27,6 +46,7 @@ import usw.suwiki.domain.user.user.controller.dto.UserResponseDto.LoadMyRestrict
 import usw.suwiki.domain.user.user.controller.dto.UserResponseDto.UserInformationResponseForm;
 import usw.suwiki.domain.user.userIsolation.UserIsolation;
 import usw.suwiki.domain.user.userIsolation.service.UserIsolationCRUDService;
+import usw.suwiki.domain.userlecture.viewexam.service.ViewExamCRUDService;
 import usw.suwiki.global.ResponseForm;
 import usw.suwiki.global.exception.errortype.AccountException;
 import usw.suwiki.global.jwt.JwtAgent;
@@ -34,18 +54,6 @@ import usw.suwiki.global.util.emailBuild.BuildEmailAuthForm;
 import usw.suwiki.global.util.emailBuild.BuildFindLoginIdForm;
 import usw.suwiki.global.util.emailBuild.BuildFindPasswordForm;
 import usw.suwiki.global.util.mailsender.EmailSender;
-
-import javax.servlet.http.Cookie;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static usw.suwiki.domain.postreport.EvaluatePostReport.buildEvaluatePostReport;
-import static usw.suwiki.domain.postreport.ExamPostReport.buildExamPostReport;
-import static usw.suwiki.domain.user.user.controller.dto.UserResponseDto.UserInformationResponseForm.buildMyPageResponseForm;
-import static usw.suwiki.global.exception.ExceptionType.*;
-import static usw.suwiki.global.util.apiresponse.ApiResponseFactory.*;
 
 @Service
 @RequiredArgsConstructor
@@ -98,10 +106,13 @@ public class UserBusinessService {
         if (userCRUDService.loadWrappedUserFromLoginId(loginId).isPresent() ||
                 userIsolationCRUDService.loadWrappedUserFromLoginId(loginId).isPresent() ||
                 userCRUDService.loadWrappedUserFromEmail(email).isPresent() ||
-                userIsolationCRUDService.loadWrappedUserFromEmail(email).isPresent())
+                userIsolationCRUDService.loadWrappedUserFromEmail(email).isPresent()) {
             throw new AccountException(LOGIN_ID_OR_EMAIL_OVERLAP);
+        }
 
-        if (!email.contains(MAIL_FORM)) throw new AccountException(IS_NOT_EMAIL_FORM);
+        if (!email.contains(MAIL_FORM)) {
+            throw new AccountException(IS_NOT_EMAIL_FORM);
+        }
 
         User user = User.makeUser(loginId, bCryptPasswordEncoder.encode(password), email);
         userCRUDService.saveUser(user);
@@ -137,10 +148,14 @@ public class UserBusinessService {
 
     public Map<String, Boolean> executeFindPw(String loginId, String email) {
         Optional<User> userByLoginId = userCRUDService.loadWrappedUserFromLoginId(loginId);
-        if (userByLoginId.isEmpty()) throw new AccountException(USER_NOT_FOUND_BY_LOGINID);
+        if (userByLoginId.isEmpty()) {
+            throw new AccountException(USER_NOT_FOUND_BY_LOGINID);
+        }
 
         Optional<User> userByEmail = userCRUDService.loadWrappedUserFromEmail(email);
-        if (userByEmail.isEmpty()) throw new AccountException(USER_NOT_FOUND_BY_EMAIL);
+        if (userByEmail.isEmpty()) {
+            throw new AccountException(USER_NOT_FOUND_BY_EMAIL);
+        }
 
         Optional<UserIsolation> isolationUserByLoginId =
                 userIsolationCRUDService.loadWrappedUserFromLoginId(loginId);
@@ -246,7 +261,9 @@ public class UserBusinessService {
             EvaluateReportForm evaluateReportForm,
             String Authorization
     ) {
-        if (jwtAgent.getUserIsRestricted(Authorization)) throw new AccountException(USER_RESTRICTED);
+        if (jwtAgent.getUserIsRestricted(Authorization)) {
+            throw new AccountException(USER_RESTRICTED);
+        }
         Long reportingUserIdx = jwtAgent.getId(Authorization);
         EvaluatePost evaluatePost = evaluatePostCRUDService.loadEvaluatePostFromEvaluatePostIdx(
                 evaluateReportForm.evaluateIdx());
@@ -266,7 +283,9 @@ public class UserBusinessService {
             ExamReportForm examReportForm,
             String Authorization
     ) {
-        if (jwtAgent.getUserIsRestricted(Authorization)) throw new AccountException(USER_RESTRICTED);
+        if (jwtAgent.getUserIsRestricted(Authorization)) {
+            throw new AccountException(USER_RESTRICTED);
+        }
         Long reportingUserIdx = jwtAgent.getId(Authorization);
         ExamPost examPost = examPostCRUDService.loadExamPostFromExamPostIdx(
                 examReportForm.examIdx());

--- a/src/main/java/usw/suwiki/global/properties/ServerProperties.java
+++ b/src/main/java/usw/suwiki/global/properties/ServerProperties.java
@@ -1,0 +1,15 @@
+package usw.suwiki.global.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@RequiredArgsConstructor
+@ConstructorBinding
+@ConfigurationProperties(prefix = "server")
+public class ServerProperties {
+    private final String domain;
+    private final int port;
+}

--- a/src/main/java/usw/suwiki/global/util/emailBuild/BuildEmailAuthForm.java
+++ b/src/main/java/usw/suwiki/global/util/emailBuild/BuildEmailAuthForm.java
@@ -5,15 +5,17 @@ import org.springframework.stereotype.Component;
 import usw.suwiki.domain.confirmationtoken.ConfirmationToken;
 import usw.suwiki.global.properties.ServerProperties;
 
-@Component
+@Component  // TODO refactor: Component 제거. -> ServerProperties 빈 주입 방법 고민
 @RequiredArgsConstructor
 public class BuildEmailAuthForm {
     private static final String CONFIRMATION_TOKEN_URL = "/v2/confirmation-token/verify/?token=";
     private final ServerProperties serverProperties;
 
+    // TODO: refactor static 메서드 고민. serverProperties를 외부에서 주입받아야 함
     public String buildEmail(ConfirmationToken confirmationToken) {
         String redirectUrl = buildRedirectUrl(confirmationToken);
 
+        // TODO refactor: 반복성 제거. 템플릿 메서드 패턴 혹은 타임 리프 고민
         return "<center>\n" +
                 "\t<img class=\"suwikilogo\"src=\"https://avatars.githubusercontent.com/u/96416159?s=200&v=4\" style=\"display:block; \"alt=\"SUWIKILOGO\">"
                 +

--- a/src/main/java/usw/suwiki/global/util/emailBuild/BuildEmailAuthForm.java
+++ b/src/main/java/usw/suwiki/global/util/emailBuild/BuildEmailAuthForm.java
@@ -1,18 +1,28 @@
 package usw.suwiki.global.util.emailBuild;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import usw.suwiki.domain.confirmationtoken.ConfirmationToken;
+import usw.suwiki.global.properties.ServerProperties;
 
 @Component
+@RequiredArgsConstructor
 public class BuildEmailAuthForm {
-    public String buildEmail(String link) {
+    private static final String CONFIRMATION_TOKEN_URL = "/v2/confirmation-token/verify/?token=";
+    private final ServerProperties serverProperties;
+
+    public String buildEmail(ConfirmationToken confirmationToken) {
+        String redirectUrl = buildRedirectUrl(confirmationToken);
+
         return "<center>\n" +
-                "\t<img class=\"suwikilogo\"src=\"https://avatars.githubusercontent.com/u/96416159?s=200&v=4\" style=\"display:block; \"alt=\"SUWIKILOGO\">" +
+                "\t<img class=\"suwikilogo\"src=\"https://avatars.githubusercontent.com/u/96416159?s=200&v=4\" style=\"display:block; \"alt=\"SUWIKILOGO\">"
+                +
                 "\t<div class=container>\n" +
                 "\t\t안녕하세요. 수원대학교 강의평가 플랫폼 SUWIKI 입니다.\n" +
                 "\t\t<p>\n" +
                 "                <b>재학생 인증 메일 전송해드립니다. </b>\n" +
                 "\t\t<br>\n" +
-                "\t\t" + "<a href=" + link + ">클릭하여 이메일 인증하기</a>" + "\n" +
+                "\t\t" + "<a href=" + redirectUrl + ">클릭하여 이메일 인증하기</a>" + "\n" +
                 "                <p>\n" +
                 "<br>" +
                 "                위 링크를 클릭하시면 정상적으로 서비스 이용이 가능합니다." + "\n" +
@@ -22,5 +32,9 @@ public class BuildEmailAuthForm {
                 "\t\t감사합니다.\n" +
                 "\t</div>\n" +
                 "</center>";
+    }
+
+    private String buildRedirectUrl(ConfirmationToken confirmationToken) {
+        return serverProperties.getDomain() + CONFIRMATION_TOKEN_URL + confirmationToken.getToken();
     }
 }


### PR DESCRIPTION
## 🙋 어떤 PR인가요?
이슈 #66 을 반영한 PR입니다.

## 📝 작업 상세
- 의존성 추가: configuration
- 구현 : `@ConfigurationProperties` 적용한 서버 프로퍼티 객체. `@ConstructorBinding` 을 이용한 필드 생성자 주입
- 파일 수정 : yml 프로퍼티 파일에 server 정보 추가 (깃허브 환경변수 수정)

## 🙏 To Reviewers
희조님 아자자 레포지토리를 봤는데 (`KakaoProperties`) `@ConstructorBinding` 없이 Setter을 방지하셨더라구요?
어떻게 하신건지 궁금합니다!

제가 참고한 레퍼런스입니다. 
[Spring Boot에서 properties 값 주입받기](https://tecoble.techcourse.co.kr/post/2020-09-29-spring-properties-binding/)

## 🧐 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
- [x]  정상동작하는지, 테스트 통과하는지 다시 한번 확인해주세요.
