### PR TITLE
fix: 강의 검색시 쿼리 교수명 키워드 누락

### DIFF
--- a/src/main/java/usw/suwiki/domain/lecture/controller/dto/LectureWithScheduleResponse.java
+++ b/src/main/java/usw/suwiki/domain/lecture/controller/dto/LectureWithScheduleResponse.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import usw.suwiki.domain.lecture.domain.Lecture;
-import usw.suwiki.global.util.apiresponse.ResponseStringManipulator;
+import usw.suwiki.global.util.apiresponse.ResponseFieldManipulationUtils;
 
 @Getter
 @Builder
@@ -27,7 +27,7 @@ public class LectureWithScheduleResponse {
     public static LectureWithScheduleResponse of(
             Lecture lecture
     ) {
-        final String professorName = ResponseStringManipulator.resolveLiteralNull(lecture.getProfessor());
+        final String professorName = ResponseFieldManipulationUtils.resolveLiteralNull(lecture.getProfessor());
         return LectureWithScheduleResponse.builder()
                 .id(lecture.getId())
                 .name(lecture.getName())

--- a/src/main/java/usw/suwiki/domain/lecture/controller/dto/LectureWithScheduleResponse.java
+++ b/src/main/java/usw/suwiki/domain/lecture/controller/dto/LectureWithScheduleResponse.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import usw.suwiki.domain.lecture.domain.Lecture;
+import usw.suwiki.global.util.apiresponse.ResponseStringManipulator;
 
 @Getter
 @Builder
@@ -26,10 +27,11 @@ public class LectureWithScheduleResponse {
     public static LectureWithScheduleResponse of(
             Lecture lecture
     ) {
+        final String professorName = ResponseStringManipulator.resolveLiteralNull(lecture.getProfessor());
         return LectureWithScheduleResponse.builder()
                 .id(lecture.getId())
                 .name(lecture.getName())
-                .professorName(lecture.getProfessor())
+                .professorName(professorName)
                 .type(lecture.getType())
                 .major(lecture.getMajorType())
                 .grade(lecture.getLectureDetail().getGrade())

--- a/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureCustomRepositoryImpl.java
+++ b/src/main/java/usw/suwiki/domain/lecture/domain/repository/LectureCustomRepositoryImpl.java
@@ -41,7 +41,7 @@ public class LectureCustomRepositoryImpl implements LectureCustomRepository { //
     ) {
         JPAQuery<Lecture> query = queryFactory.selectFrom(lecture)
                 .where(gtCursorId(cursorId))
-                .where(containsKeyword(keyword))
+                .where(containsLectureKeyword(keyword))
                 .where(eqMajorType(majorType))
                 .where(eqGrade(grade))
                 .where(lecture.semester.endsWith(currentSemester))
@@ -210,11 +210,12 @@ public class LectureCustomRepositoryImpl implements LectureCustomRepository { //
         return lecture.id.gt(cursorId);
     }
 
-    private BooleanExpression containsKeyword(String keyword) {
+    private BooleanExpression containsLectureKeyword(String keyword) {
         if (Objects.isNull(keyword)) {
             return null;
         }
-        return lecture.name.contains(keyword);
+        return lecture.name.contains(keyword)
+                .or(lecture.professor.contains(keyword));
     }
 
     private BooleanExpression eqMajorType(String majorType) {

--- a/src/main/java/usw/suwiki/global/util/apiresponse/ResponseFieldManipulationUtils.java
+++ b/src/main/java/usw/suwiki/global/util/apiresponse/ResponseFieldManipulationUtils.java
@@ -2,7 +2,7 @@ package usw.suwiki.global.util.apiresponse;
 
 import java.util.Objects;
 
-public class ResponseStringManipulator {
+public class ResponseFieldManipulationUtils {
     public static final String KOREAN_NONE = "없음";
 
     public static String resolveLiteralNull(String value) {     // TODO 데이터 적재 로직 "null" -> null로 변경 후 메서드 삭제

--- a/src/main/java/usw/suwiki/global/util/apiresponse/ResponseStringManipulator.java
+++ b/src/main/java/usw/suwiki/global/util/apiresponse/ResponseStringManipulator.java
@@ -1,0 +1,21 @@
+package usw.suwiki.global.util.apiresponse;
+
+import java.util.Objects;
+
+public class ResponseStringManipulator {
+    public static final String KOREAN_NONE = "없음";
+
+    public static String resolveLiteralNull(String value) {     // TODO 데이터 적재 로직 "null" -> null로 변경 후 메서드 삭제
+        if (Objects.equals(value, "null")) {
+            return KOREAN_NONE;
+        }
+        return value;
+    }
+
+    public static String resolveNull(String value) {
+        if (Objects.isNull(value)) {
+            return KOREAN_NONE;
+        }
+        return value;
+    }
+}

--- a/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/lecture/LectureRepositoryTest.java
@@ -91,7 +91,7 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 �
                     "테스트학개론",
                     "중핵",
                     "교양 아님",
-                    "우문균",
+                    "장성태",
                     firstGradeLectureDetail
             ));
             lectureRepository.save(LectureTemplate.createDummyLecture(
@@ -99,7 +99,7 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 �
                     "도전과 창조",
                     "중핵",
                     "교양",
-                    "우문균",
+                    "소크라테스",
                     firstGradeLectureDetail
             ));
             lectureRepository.save(LectureTemplate.createDummyLecture(
@@ -168,7 +168,9 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 �
         // given
         long cursorId = 0;
         int limit = 80;
-        String keyword = "도전";
+        String lectureNameKeyword = "도전";
+        String professorNameKeyword = "장성태";
+        String bothKeyword = "테스";
         String majorType = "교양";
         int grade = 2;
 
@@ -181,10 +183,24 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 �
                 null,
                 null
         );
-        Slice<Lecture> keywordResult = lectureRepository.findCurrentSemesterLectures(
+        Slice<Lecture> lectureKeywordResult = lectureRepository.findCurrentSemesterLectures(
                 cursorId,
                 limit,
-                keyword,
+                lectureNameKeyword,
+                null,
+                null
+        );
+        Slice<Lecture> professorKeywordResult = lectureRepository.findCurrentSemesterLectures(
+                cursorId,
+                limit,
+                professorNameKeyword,
+                null,
+                null
+        );
+        Slice<Lecture> bothKeywordResult = lectureRepository.findCurrentSemesterLectures(
+                cursorId,
+                limit,
+                bothKeyword,
                 null,
                 null
         );
@@ -205,7 +221,9 @@ public class LectureRepositoryTest {    // TODO: https://7357.tistory.com/339 �
 
         // then
         assertThat(currentSemester.getContent().size()).isEqualTo(80);
-        assertThat(keywordResult.getContent().size()).isEqualTo(60);
+        assertThat(lectureKeywordResult.getContent().size()).isEqualTo(60);
+        assertThat(professorKeywordResult.getContent().size()).isEqualTo(20);
+        assertThat(bothKeywordResult.getContent().size()).isEqualTo(40);    // 강의명 테스트학개론, 교수명 소크라테스
         assertThat(majorResult.getContent().size()).isEqualTo(40);
         assertThat(majorGradeResult.getContent().size()).isEqualTo(20);
     }


### PR DESCRIPTION
## 🙋 어떤 PR인가요?
시간표용 강의 검색 API의 키워드가 교수명을 포함해 검색해야 하는 부분이 누락되어 수정했습니다.

추가적으로 API 명세가 변경되어 "null" 혹은 null로 응답되는 데이터들을 "없음"으로 응답하는 방식으로 변경되었습니다.

## 📝 작업 상세

## 🙏 To Reviewers

## 🧐 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
- [x]  정상동작하는지, 테스트 통과하는지 다시 한번 확인해주세요.
