### PR TITLE
feat: 버전 강제 업데이트 API

### DIFF
--- a/src/main/java/usw/suwiki/domain/evaluatepost/domain/EvaluatePost.java
+++ b/src/main/java/usw/suwiki/domain/evaluatepost/domain/EvaluatePost.java
@@ -1,6 +1,5 @@
 package usw.suwiki.domain.evaluatepost.domain;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -13,7 +12,6 @@ import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.LastModifiedDate;
 import usw.suwiki.domain.evaluatepost.controller.dto.EvaluatePostSaveDto;
 import usw.suwiki.domain.evaluatepost.controller.dto.EvaluatePostUpdateDto;
 import usw.suwiki.domain.lecture.domain.Lecture;
@@ -50,8 +48,6 @@ public class EvaluatePost extends BaseTimeEntity {
     @JoinColumn(name = "user_idx")
     private User user;
 
-    @LastModifiedDate
-    private LocalDateTime modifiedDate;
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;    //주관적인 강의평가 입력내용

--- a/src/main/java/usw/suwiki/domain/exampost/domain/ExamPost.java
+++ b/src/main/java/usw/suwiki/domain/exampost/domain/ExamPost.java
@@ -1,18 +1,22 @@
 package usw.suwiki.domain.exampost.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.LastModifiedDate;
-import usw.suwiki.domain.exampost.controller.dto.ExamPostsSaveDto;
 import usw.suwiki.domain.exampost.controller.dto.ExamPostUpdateDto;
+import usw.suwiki.domain.exampost.controller.dto.ExamPostsSaveDto;
 import usw.suwiki.domain.lecture.domain.Lecture;
 import usw.suwiki.domain.user.user.User;
 import usw.suwiki.global.BaseTimeEntity;
-
-import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,9 +33,6 @@ public class ExamPost extends BaseTimeEntity {
     private String examType;
     private String examInfo;    //시험방식
     private String examDifficulty;    //난이도
-
-    @LastModifiedDate
-    private LocalDateTime modifiedDate;
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;

--- a/src/main/java/usw/suwiki/domain/lecture/domain/Lecture.java
+++ b/src/main/java/usw/suwiki/domain/lecture/domain/Lecture.java
@@ -1,6 +1,5 @@
 package usw.suwiki.domain.lecture.domain;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -16,7 +15,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.LastModifiedDate;
 import usw.suwiki.domain.evaluatepost.domain.EvaluatePost;
 import usw.suwiki.domain.evaluatepost.service.dto.EvaluatePostsToLecture;
 import usw.suwiki.global.BaseTimeEntity;
@@ -52,8 +50,6 @@ public class Lecture extends BaseTimeEntity {
 
     private int postsCount = 0;
 
-    @LastModifiedDate
-    private LocalDateTime modifiedDate;
 
     @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EvaluatePost> evaluatePostList = new ArrayList<>();

--- a/src/main/java/usw/suwiki/domain/notice/domain/Notice.java
+++ b/src/main/java/usw/suwiki/domain/notice/domain/Notice.java
@@ -1,16 +1,13 @@
 package usw.suwiki.domain.notice.domain;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.LastModifiedDate;
-import usw.suwiki.domain.notice.controller.dto.NoticeSaveOrUpdateDto;
-import usw.suwiki.global.BaseTimeEntity;
-
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import usw.suwiki.domain.notice.controller.dto.NoticeSaveOrUpdateDto;
+import usw.suwiki.global.BaseTimeEntity;
 
 @Getter
 @NoArgsConstructor
@@ -19,9 +16,6 @@ public class Notice extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @LastModifiedDate
-    private LocalDateTime modifiedDate;
 
     private String title;
     private String content;

--- a/src/main/java/usw/suwiki/domain/version/controller/ClientAppVersionController.java
+++ b/src/main/java/usw/suwiki/domain/version/controller/ClientAppVersionController.java
@@ -1,0 +1,27 @@
+package usw.suwiki.domain.version.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.domain.version.dto.response.CheckUpdateMandatoryResponse;
+import usw.suwiki.domain.version.service.ClientAppVersionService;
+
+@Slf4j
+@RestController
+@RequestMapping("/client/version")
+@RequiredArgsConstructor
+public class ClientAppVersionController {
+    private final ClientAppVersionService clientAppVersionService;
+
+    @GetMapping("/update-mandatory")
+    public ResponseEntity<CheckUpdateMandatoryResponse> checkIsUpdateMandatory(
+            @RequestParam String os,
+            @RequestParam Integer versionCode
+    ) {
+        return ResponseEntity.ok(clientAppVersionService.checkIsUpdateMandatory(os, versionCode));
+    }
+}

--- a/src/main/java/usw/suwiki/domain/version/dto/response/CheckUpdateMandatoryResponse.java
+++ b/src/main/java/usw/suwiki/domain/version/dto/response/CheckUpdateMandatoryResponse.java
@@ -1,0 +1,19 @@
+package usw.suwiki.domain.version.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CheckUpdateMandatoryResponse {
+    private final Boolean isUpdateMandatory;
+
+    public static CheckUpdateMandatoryResponse from(boolean isUpdateMandatory) {
+        return CheckUpdateMandatoryResponse.builder()
+                .isUpdateMandatory(isUpdateMandatory)
+                .build();
+    }
+}

--- a/src/main/java/usw/suwiki/domain/version/entity/ClientAppVersion.java
+++ b/src/main/java/usw/suwiki/domain/version/entity/ClientAppVersion.java
@@ -35,17 +35,17 @@ public class ClientAppVersion extends BaseTimeEntity {
     private Integer versionCode;
 
     @NotNull
-    private Boolean isUpdateRequired;
+    private Boolean isVital;
 
     @Size(max = 2000)
     private String description;
 
 
     @Builder
-    public ClientAppVersion(ClientOS os, Integer versionCode, Boolean isUpdateRequired, String description) {
+    public ClientAppVersion(ClientOS os, Integer versionCode, Boolean isVital, String description) {
         this.os = os;
         this.versionCode = versionCode;
-        this.isUpdateRequired = isUpdateRequired;
+        this.isVital = isVital;
         this.description = description;
     }
 }

--- a/src/main/java/usw/suwiki/domain/version/entity/ClientAppVersion.java
+++ b/src/main/java/usw/suwiki/domain/version/entity/ClientAppVersion.java
@@ -19,19 +19,27 @@ import usw.suwiki.global.BaseTimeEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "UNIQUE_OS_AND_VERSION_CODE",
+                columnNames = {"os", "version_code"}
+        )
+})
 public class ClientAppVersion extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "client_version_id")
+    @Column(name = "client_app_version_id")
     private Long id;
 
     @Enumerated(EnumType.STRING)
     @NotNull
+    @Column(name = "os")
     private ClientOS os;
 
     @NotNull
     @Min(value = 0)
+    @Column(name = "version_code")
     private Integer versionCode;
 
     @NotNull

--- a/src/main/java/usw/suwiki/domain/version/entity/ClientAppVersion.java
+++ b/src/main/java/usw/suwiki/domain/version/entity/ClientAppVersion.java
@@ -7,6 +7,8 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -15,6 +17,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import usw.suwiki.global.BaseTimeEntity;
+import usw.suwiki.global.exception.ExceptionType;
+import usw.suwiki.global.exception.errortype.VersionException;
 
 @Entity
 @Getter
@@ -55,5 +59,12 @@ public class ClientAppVersion extends BaseTimeEntity {
         this.versionCode = versionCode;
         this.isVital = isVital;
         this.description = description;
+    }
+
+    public boolean judgeIsUpdateRequired(ClientOS os, Integer otherVersionCode) {
+        if (!this.os.equals(os)) {
+            throw new VersionException(ExceptionType.SERVER_ERROR);
+        }
+        return this.isVital && this.versionCode > otherVersionCode;
     }
 }

--- a/src/main/java/usw/suwiki/domain/version/entity/ClientAppVersion.java
+++ b/src/main/java/usw/suwiki/domain/version/entity/ClientAppVersion.java
@@ -1,0 +1,51 @@
+package usw.suwiki.domain.version.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import usw.suwiki.global.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClientAppVersion extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "client_version_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private ClientOS os;
+
+    @NotNull
+    @Min(value = 0)
+    private Integer versionCode;
+
+    @NotNull
+    private Boolean isUpdateRequired;
+
+    @Size(max = 2000)
+    private String description;
+
+
+    @Builder
+    public ClientAppVersion(ClientOS os, Integer versionCode, Boolean isUpdateRequired, String description) {
+        this.os = os;
+        this.versionCode = versionCode;
+        this.isUpdateRequired = isUpdateRequired;
+        this.description = description;
+    }
+}

--- a/src/main/java/usw/suwiki/domain/version/entity/ClientAppVersion.java
+++ b/src/main/java/usw/suwiki/domain/version/entity/ClientAppVersion.java
@@ -61,7 +61,7 @@ public class ClientAppVersion extends BaseTimeEntity {
         this.description = description;
     }
 
-    public boolean judgeIsUpdateRequired(ClientOS os, Integer otherVersionCode) {
+    public boolean judgeIsUpdateMandatory(ClientOS os, Integer otherVersionCode) {
         if (!this.os.equals(os)) {
             throw new VersionException(ExceptionType.SERVER_ERROR);
         }

--- a/src/main/java/usw/suwiki/domain/version/entity/ClientOS.java
+++ b/src/main/java/usw/suwiki/domain/version/entity/ClientOS.java
@@ -1,6 +1,7 @@
 package usw.suwiki.domain.version.entity;
 
 import java.util.Arrays;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import usw.suwiki.global.exception.ExceptionType;
 import usw.suwiki.global.exception.errortype.VersionException;
@@ -13,10 +14,13 @@ public enum ClientOS implements KeyValueEnumModel<String> {
     private final String value;
 
     public static ClientOS ofString(String param) {
+        if (Objects.isNull(param)) {
+            throw new VersionException(ExceptionType.INVALID_CLIENT_OS);
+        }
         return Arrays.stream(ClientOS.values())
                 .filter(v -> v.getValue().equals(param.toUpperCase()))
                 .findFirst()
-                .orElseThrow(() -> new VersionException(ExceptionType.INVALID_CLIENT_OS));
+                .orElseThrow(() -> new VersionException(ExceptionType.COMMON_CLIENT_ERROR));
     }
 
     @Override

--- a/src/main/java/usw/suwiki/domain/version/entity/ClientOS.java
+++ b/src/main/java/usw/suwiki/domain/version/entity/ClientOS.java
@@ -1,0 +1,31 @@
+package usw.suwiki.domain.version.entity;
+
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import usw.suwiki.global.exception.ExceptionType;
+import usw.suwiki.global.exception.errortype.VersionException;
+import usw.suwiki.global.util.enums.KeyValueEnumModel;
+
+@RequiredArgsConstructor
+public enum ClientOS implements KeyValueEnumModel<String> {
+    ANDROID("ANDROID"), IOS("IOS"), WEB("WEB");
+
+    private final String value;
+
+    public static ClientOS ofString(String param) {
+        return Arrays.stream(ClientOS.values())
+                .filter(v -> v.getValue().equals(param.toUpperCase()))
+                .findFirst()
+                .orElseThrow(() -> new VersionException(ExceptionType.INVALID_CLIENT_OS));
+    }
+
+    @Override
+    public String getKey() {
+        return name();
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/usw/suwiki/domain/version/repository/ClientAppVersionRepository.java
+++ b/src/main/java/usw/suwiki/domain/version/repository/ClientAppVersionRepository.java
@@ -1,8 +1,11 @@
 package usw.suwiki.domain.version.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import usw.suwiki.domain.version.entity.ClientAppVersion;
+import usw.suwiki.domain.version.entity.ClientOS;
 
 public interface ClientAppVersionRepository extends JpaRepository<ClientAppVersion, Long> {
+    Optional<ClientAppVersion> findFirstByOsAndIsVitalTrueOrderByVersionCodeDesc(ClientOS os);
 
 }

--- a/src/main/java/usw/suwiki/domain/version/repository/ClientAppVersionRepository.java
+++ b/src/main/java/usw/suwiki/domain/version/repository/ClientAppVersionRepository.java
@@ -1,0 +1,8 @@
+package usw.suwiki.domain.version.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import usw.suwiki.domain.version.entity.ClientAppVersion;
+
+public interface ClientAppVersionRepository extends JpaRepository<ClientAppVersion, Long> {
+
+}

--- a/src/main/java/usw/suwiki/domain/version/service/ClientAppVersionService.java
+++ b/src/main/java/usw/suwiki/domain/version/service/ClientAppVersionService.java
@@ -1,0 +1,31 @@
+package usw.suwiki.domain.version.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import usw.suwiki.domain.version.dto.response.CheckUpdateMandatoryResponse;
+import usw.suwiki.domain.version.entity.ClientAppVersion;
+import usw.suwiki.domain.version.entity.ClientOS;
+import usw.suwiki.domain.version.repository.ClientAppVersionRepository;
+import usw.suwiki.global.exception.ExceptionType;
+import usw.suwiki.global.exception.errortype.VersionException;
+
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ClientAppVersionService {
+    private final ClientAppVersionRepository clientAppVersionRepository;
+
+    public CheckUpdateMandatoryResponse checkIsUpdateMandatory(String os, int versionCode) {
+        ClientOS clientOS = ClientOS.ofString(os);
+        ClientAppVersion clientAppVersion = clientAppVersionRepository
+                .findFirstByOsAndIsVitalTrueOrderByVersionCodeDesc(clientOS)
+                .orElseThrow(() -> new VersionException(ExceptionType.SERVER_ERROR));
+
+        boolean isUpdateMandatory = clientAppVersion.judgeIsUpdateMandatory(clientOS, versionCode);
+        return CheckUpdateMandatoryResponse.from(isUpdateMandatory);
+    }
+}

--- a/src/main/java/usw/suwiki/global/BaseTimeEntity.java
+++ b/src/main/java/usw/suwiki/global/BaseTimeEntity.java
@@ -1,19 +1,22 @@
 package usw.suwiki.global;
 
-import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
+import java.time.LocalDateTime;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
 @Getter
-@MappedSuperclass   //Jpa Entity 클래스들이 BastTimeEntity 를 상속할 경우, 필드들도 칼럼으로 인식된다.
-@EntityListeners(AuditingEntityListener.class)  //Auditing 기능을 포함시킨다.
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
-    @CreatedDate    // Entity가 생성되어 저장할 때 시간이 자동 저장된다.
+    @CreatedDate
     private LocalDateTime createDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
 }

--- a/src/main/java/usw/suwiki/global/exception/ExceptionType.java
+++ b/src/main/java/usw/suwiki/global/exception/ExceptionType.java
@@ -114,6 +114,13 @@ public enum ExceptionType {
 
     INVALID_TIMETABLE_CELL_SCHEDULE("TIMETABLE210", "유효하지 않은 셀 스케줄입니다.", BAD_REQUEST),
     OVERLAPPED_TIMETABLE_CELL_SCHEDULE("TIMETABLE211", "시간표에 중복되는 요일-교시입니다.", CONFLICT),
+
+    /**
+     * Domain : Version
+     */
+    INVALID_CLIENT_OS("VERSION110", "유효하지 않은 클라이언트 OS 입니다.", BAD_REQUEST),
+
+
     /**
      * 공통
      */

--- a/src/main/java/usw/suwiki/global/exception/ExceptionType.java
+++ b/src/main/java/usw/suwiki/global/exception/ExceptionType.java
@@ -116,8 +116,9 @@ public enum ExceptionType {
     OVERLAPPED_TIMETABLE_CELL_SCHEDULE("TIMETABLE211", "시간표에 중복되는 요일-교시입니다.", CONFLICT),
 
     /**
-     * Domain : Version
+     * Domain : Client Version
      */
+    CLIENT_VERSION_NOT_FOUND("VERSION001", "존재하지 않는 클라이언트 버전입니다.", NOT_FOUND),
     INVALID_CLIENT_OS("VERSION110", "유효하지 않은 클라이언트 OS 입니다.", BAD_REQUEST),
 
 

--- a/src/main/java/usw/suwiki/global/exception/errortype/VersionException.java
+++ b/src/main/java/usw/suwiki/global/exception/errortype/VersionException.java
@@ -1,0 +1,10 @@
+package usw.suwiki.global.exception.errortype;
+
+import usw.suwiki.global.exception.ExceptionType;
+
+public class VersionException extends BaseException {
+    public VersionException(ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+
+}

--- a/src/test/java/usw/suwiki/global/annotation/SuwikiJpaTest.java
+++ b/src/test/java/usw/suwiki/global/annotation/SuwikiJpaTest.java
@@ -1,0 +1,23 @@
+package usw.suwiki.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import usw.suwiki.config.TestJpaConfig;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+
+@DataJpaTest
+@Import(TestJpaConfig.class)
+@TestMethodOrder(MethodOrderer.DisplayName.class)
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public @interface SuwikiJpaTest {
+}

--- a/src/test/java/usw/suwiki/global/annotation/SuwikiMockitoTest.java
+++ b/src/test/java/usw/suwiki/global/annotation/SuwikiMockitoTest.java
@@ -1,0 +1,18 @@
+package usw.suwiki.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+
+@ExtendWith(MockitoExtension.class)
+@TestMethodOrder(MethodOrderer.DisplayName.class)
+public @interface SuwikiMockitoTest {
+}

--- a/src/test/java/usw/suwiki/repository/clientappversion/ClientAppVersionRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/clientappversion/ClientAppVersionRepositoryTest.java
@@ -17,6 +17,7 @@ import usw.suwiki.domain.version.entity.ClientAppVersion;
 import usw.suwiki.domain.version.entity.ClientOS;
 import usw.suwiki.domain.version.repository.ClientAppVersionRepository;
 import usw.suwiki.global.annotation.SuwikiJpaTest;
+import usw.suwiki.global.exception.errortype.VersionException;
 
 @SuwikiJpaTest
 public class ClientAppVersionRepositoryTest {
@@ -97,11 +98,11 @@ public class ClientAppVersionRepositoryTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(()->clientAppVersionRepository.save(nullOsVersion))
+        assertThatThrownBy(() -> clientAppVersionRepository.save(nullOsVersion))
                 .isExactlyInstanceOf(ConstraintViolationException.class);
-        assertThatThrownBy(()->clientAppVersionRepository.save(nullCodeVersion))
+        assertThatThrownBy(() -> clientAppVersionRepository.save(nullCodeVersion))
                 .isExactlyInstanceOf(ConstraintViolationException.class);
-        assertThatThrownBy(()->clientAppVersionRepository.save(nullIsVitalVersion))
+        assertThatThrownBy(() -> clientAppVersionRepository.save(nullIsVitalVersion))
                 .isExactlyInstanceOf(ConstraintViolationException.class);
     }
 
@@ -137,5 +138,21 @@ public class ClientAppVersionRepositoryTest {
         assertThat(optionalClientAppVersion).isPresent();
         assertThat(optionalClientAppVersion.get().getVersionCode()).isEqualTo(2);
     }
+
+    @Test
+    @DisplayName("클라이언트 앱 버전 조회 - 업데이트 필수 여부 확인")
+    public void CLIENT_APP_VERSION_CHECK_IS_UPDATE_REQUIRED() {
+        // given
+        Optional<ClientAppVersion> optionalClientAppVersion = clientAppVersionRepository
+                .findFirstByOsAndIsVitalTrueOrderByVersionCodeDesc(ClientOS.ANDROID);
+
+        // when & then
+        assertThat(optionalClientAppVersion).isPresent();
+        assertThat(optionalClientAppVersion.get().judgeIsUpdateRequired(ClientOS.ANDROID, 1))
+                .isTrue();
+        assertThatThrownBy(() -> optionalClientAppVersion.get().judgeIsUpdateRequired(ClientOS.IOS, 1))
+                .isExactlyInstanceOf(VersionException.class);
+    }
+
 
 }

--- a/src/test/java/usw/suwiki/repository/clientappversion/ClientAppVersionRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/clientappversion/ClientAppVersionRepositoryTest.java
@@ -1,6 +1,7 @@
 package usw.suwiki.repository.clientappversion;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Optional;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import usw.suwiki.domain.version.entity.ClientAppVersion;
 import usw.suwiki.domain.version.entity.ClientOS;
 import usw.suwiki.domain.version.repository.ClientAppVersionRepository;
@@ -101,6 +103,27 @@ public class ClientAppVersionRepositoryTest {
                 .isExactlyInstanceOf(ConstraintViolationException.class);
         assertThatThrownBy(()->clientAppVersionRepository.save(nullIsVitalVersion))
                 .isExactlyInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    @DisplayName("클라이언트 앱 버전 생성 실패 - UNIQUE 제약 조건 (os, versionCode)을 준수해야 한다.")
+    public void CLIENT_APP_VERSION_CREATE_FAIL_UNIQUE_CONSTRAINT() {
+        // given
+        ClientAppVersion first = ClientAppVersion.builder()
+                .os(ClientOS.IOS)
+                .versionCode(1)
+                .isVital(false)
+                .build();
+        ClientAppVersion second = ClientAppVersion.builder()
+                .os(ClientOS.IOS)
+                .versionCode(1)
+                .isVital(false)
+                .build();
+
+        // when & then
+        assertThatNoException().isThrownBy(() -> clientAppVersionRepository.save(first));
+        assertThatThrownBy(() -> clientAppVersionRepository.save(second))
+                .isExactlyInstanceOf(DataIntegrityViolationException.class);
     }
 
     @Test

--- a/src/test/java/usw/suwiki/repository/clientappversion/ClientAppVersionRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/clientappversion/ClientAppVersionRepositoryTest.java
@@ -24,7 +24,10 @@ public class ClientAppVersionRepositoryTest {
     @PersistenceContext
     private EntityManager entityManager;
 
-    private ClientAppVersion dummyClientAppVersion;
+    private ClientAppVersion dummyClientAppVersionFirst;
+    private ClientAppVersion dummyClientAppVersionSecond;
+    private ClientAppVersion dummyClientAppVersionThird;
+
 
     @BeforeEach
     public void setUp() {
@@ -41,12 +44,12 @@ public class ClientAppVersionRepositoryTest {
         ClientAppVersion androidVersion3 = ClientAppVersion.builder()
                 .os(ClientOS.ANDROID)
                 .versionCode(3)
-                .isVital(true)
+                .isVital(false)
                 .build();
 
-        clientAppVersionRepository.save(androidVersion1);
-        clientAppVersionRepository.save(androidVersion2);
-        clientAppVersionRepository.save(androidVersion3);
+        this.dummyClientAppVersionFirst = clientAppVersionRepository.save(androidVersion1);
+        this.dummyClientAppVersionSecond = clientAppVersionRepository.save(androidVersion2);
+        this.dummyClientAppVersionThird = clientAppVersionRepository.save(androidVersion3);
 
         entityManager.clear();
     }
@@ -99,4 +102,17 @@ public class ClientAppVersionRepositoryTest {
         assertThatThrownBy(()->clientAppVersionRepository.save(nullIsVitalVersion))
                 .isExactlyInstanceOf(ConstraintViolationException.class);
     }
+
+    @Test
+    @DisplayName("클라이언트 앱 버전 조회 - 특정 OS에 대한 가장 최신의 필수 버전 조회")
+    public void CLIENT_APP_VERSION_FIND_MOST_RECENT_VITAL_VERSION() {
+        // given
+        Optional<ClientAppVersion> optionalClientAppVersion = clientAppVersionRepository
+                .findFirstByOsAndIsVitalTrueOrderByVersionCodeDesc(ClientOS.ANDROID);
+
+        // when & then
+        assertThat(optionalClientAppVersion).isPresent();
+        assertThat(optionalClientAppVersion.get().getVersionCode()).isEqualTo(2);
+    }
+
 }

--- a/src/test/java/usw/suwiki/repository/clientappversion/ClientAppVersionRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/clientappversion/ClientAppVersionRepositoryTest.java
@@ -1,0 +1,102 @@
+package usw.suwiki.repository.clientappversion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import usw.suwiki.domain.version.entity.ClientAppVersion;
+import usw.suwiki.domain.version.entity.ClientOS;
+import usw.suwiki.domain.version.repository.ClientAppVersionRepository;
+import usw.suwiki.global.annotation.SuwikiJpaTest;
+
+@SuwikiJpaTest
+public class ClientAppVersionRepositoryTest {
+    @Autowired
+    ClientAppVersionRepository clientAppVersionRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private ClientAppVersion dummyClientAppVersion;
+
+    @BeforeEach
+    public void setUp() {
+        ClientAppVersion androidVersion1 = ClientAppVersion.builder()
+                .os(ClientOS.ANDROID)
+                .versionCode(1)
+                .isVital(true)
+                .build();
+        ClientAppVersion androidVersion2 = ClientAppVersion.builder()
+                .os(ClientOS.ANDROID)
+                .versionCode(2)
+                .isVital(true)
+                .build();
+        ClientAppVersion androidVersion3 = ClientAppVersion.builder()
+                .os(ClientOS.ANDROID)
+                .versionCode(3)
+                .isVital(true)
+                .build();
+
+        clientAppVersionRepository.save(androidVersion1);
+        clientAppVersionRepository.save(androidVersion2);
+        clientAppVersionRepository.save(androidVersion3);
+
+        entityManager.clear();
+    }
+
+
+    @Test
+    @DisplayName("클라이언트 앱 버전 생성")
+    public void CLIENT_APP_VERSION_CREATE() {
+        // given
+        ClientAppVersion iosAppVersion = ClientAppVersion.builder()
+                .os(ClientOS.IOS)
+                .versionCode(1)
+                .isVital(true)
+                .build();
+
+        // when
+        ClientAppVersion saved = clientAppVersionRepository.save(iosAppVersion);
+        entityManager.clear();
+        Optional<ClientAppVersion> found = clientAppVersionRepository.findById(saved.getId());
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getOs()).isEqualTo(ClientOS.IOS);
+        assertThat(found.get().getVersionCode()).isEqualTo(1);
+        assertThat(found.get().getIsVital()).isTrue();
+    }
+
+    @Test
+    @DisplayName("클라이언트 앱 버전 생성 실패 - NOT NULL 제약 조건을 준수해야 한다.")
+    public void CLIENT_APP_VERSION_CREATE_FAIL_NOT_NULL_CONSTRAINT() {
+        // given
+        ClientAppVersion nullOsVersion = ClientAppVersion.builder()
+                .versionCode(1)
+                .isVital(true)
+                .build();
+        ClientAppVersion nullCodeVersion = ClientAppVersion.builder()
+                .os(ClientOS.IOS)
+                .isVital(true)
+                .build();
+        ClientAppVersion nullIsVitalVersion = ClientAppVersion.builder()
+                .os(ClientOS.IOS)
+                .versionCode(1)
+                .build();
+
+        // when & then
+        assertThatThrownBy(()->clientAppVersionRepository.save(nullOsVersion))
+                .isExactlyInstanceOf(ConstraintViolationException.class);
+        assertThatThrownBy(()->clientAppVersionRepository.save(nullCodeVersion))
+                .isExactlyInstanceOf(ConstraintViolationException.class);
+        assertThatThrownBy(()->clientAppVersionRepository.save(nullIsVitalVersion))
+                .isExactlyInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/src/test/java/usw/suwiki/repository/clientappversion/ClientAppVersionRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/clientappversion/ClientAppVersionRepositoryTest.java
@@ -148,9 +148,9 @@ public class ClientAppVersionRepositoryTest {
 
         // when & then
         assertThat(optionalClientAppVersion).isPresent();
-        assertThat(optionalClientAppVersion.get().judgeIsUpdateRequired(ClientOS.ANDROID, 1))
+        assertThat(optionalClientAppVersion.get().judgeIsUpdateMandatory(ClientOS.ANDROID, 1))
                 .isTrue();
-        assertThatThrownBy(() -> optionalClientAppVersion.get().judgeIsUpdateRequired(ClientOS.IOS, 1))
+        assertThatThrownBy(() -> optionalClientAppVersion.get().judgeIsUpdateMandatory(ClientOS.IOS, 1))
                 .isExactlyInstanceOf(VersionException.class);
     }
 

--- a/src/test/java/usw/suwiki/repository/timetable/TimetableRepositoryTest.java
+++ b/src/test/java/usw/suwiki/repository/timetable/TimetableRepositoryTest.java
@@ -13,15 +13,8 @@ import javax.persistence.PersistenceContext;
 import javax.validation.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import usw.suwiki.config.TestJpaConfig;
 import usw.suwiki.domain.timetable.entity.Semester;
 import usw.suwiki.domain.timetable.entity.Timetable;
 import usw.suwiki.domain.timetable.entity.TimetableCell;
@@ -32,16 +25,14 @@ import usw.suwiki.domain.timetable.repository.TimetableCellRepository;
 import usw.suwiki.domain.timetable.repository.TimetableRepository;
 import usw.suwiki.domain.user.user.User;
 import usw.suwiki.domain.user.user.repository.UserRepository;
+import usw.suwiki.global.annotation.SuwikiJpaTest;
 import usw.suwiki.global.exception.ExceptionType;
 import usw.suwiki.global.exception.errortype.TimetableException;
 import usw.suwiki.template.timetable.TimetableTemplate;
 import usw.suwiki.template.timetablecell.TimetableCellTemplate;
 import usw.suwiki.template.user.UserTemplate;
 
-@DataJpaTest
-@Import(TestJpaConfig.class)
-@TestMethodOrder(MethodOrderer.DisplayName.class)
-@AutoConfigureTestDatabase(replace = Replace.NONE)
+@SuwikiJpaTest
 public class TimetableRepositoryTest {
 
     @Autowired

--- a/src/test/java/usw/suwiki/service/clientappversion/ClientAppVersionServiceTest.java
+++ b/src/test/java/usw/suwiki/service/clientappversion/ClientAppVersionServiceTest.java
@@ -1,0 +1,85 @@
+package usw.suwiki.service.clientappversion;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.when;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import usw.suwiki.domain.version.entity.ClientAppVersion;
+import usw.suwiki.domain.version.entity.ClientOS;
+import usw.suwiki.domain.version.repository.ClientAppVersionRepository;
+import usw.suwiki.domain.version.service.ClientAppVersionService;
+import usw.suwiki.global.annotation.SuwikiMockitoTest;
+import usw.suwiki.global.exception.ExceptionType;
+import usw.suwiki.global.exception.errortype.VersionException;
+
+@SuwikiMockitoTest
+public class ClientAppVersionServiceTest {
+    @InjectMocks
+    ClientAppVersionService clientAppVersionService;
+
+    @Mock
+    ClientAppVersionRepository clientAppVersionRepository;
+
+
+    @Test
+    @DisplayName("클라이언트 앱 필수 업데이트 여부 확인")
+    public void CLIENT_APP_CHECK_IS_UPDATE_MANDATORY() {
+        // given
+        ClientAppVersion clientAppVersion = ClientAppVersion.builder()
+                .os(ClientOS.ANDROID)
+                .versionCode(30)
+                .isVital(true)
+                .build();
+
+        when(clientAppVersionRepository.findFirstByOsAndIsVitalTrueOrderByVersionCodeDesc(any(ClientOS.class)))
+                .thenReturn(Optional.of(clientAppVersion));
+
+        // when & then
+        assertThatNoException()
+                .isThrownBy(() -> clientAppVersionService.checkIsUpdateMandatory("ANDROID", 20));
+        verify(clientAppVersionRepository)
+                .findFirstByOsAndIsVitalTrueOrderByVersionCodeDesc(any(ClientOS.class));
+    }
+
+    @Test
+    @DisplayName("클라이언트 앱 필수 업데이트 여부 확인 실패 - 파라미터는 모두 NOT NULL 이어야 한다.")
+    public void CLIENT_APP_CHECK_IS_UPDATE_MANDATORY_FAIL_NULL_PARAMETER() {
+        // given
+
+        // when & then
+        assertThatThrownBy(() -> clientAppVersionService.checkIsUpdateMandatory(null, 20))
+                .isExactlyInstanceOf(VersionException.class)
+                .hasMessage(ExceptionType.INVALID_CLIENT_OS.getMessage());
+    }
+
+    @Test
+    @DisplayName("클라이언트 앱 필수 업데이트 여부 확인 실패 - OS 마다 DB에 최소 하나의 is_vital = true인 레코드가 존재해야 한다.")
+    public void CLIENT_APP_CHECK_IS_UPDATE_MANDATORY_FAIL_RECORD_NOT_EXIST() {
+        // given
+        when(clientAppVersionRepository.findFirstByOsAndIsVitalTrueOrderByVersionCodeDesc(any(ClientOS.class)))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> clientAppVersionService.checkIsUpdateMandatory("ANDROID", 30))
+                .isExactlyInstanceOf(VersionException.class);
+        verify(clientAppVersionRepository)
+                .findFirstByOsAndIsVitalTrueOrderByVersionCodeDesc(any(ClientOS.class));
+    }
+
+    @Test
+    @DisplayName("클라이언트 앱 필수 업데이트 여부 확인 실패 - ClientOS ENUM에 있지 않은 os는 조회될 수 없다.")
+    public void CLIENT_APP_CHECK_IS_UPDATE_MANDATORY_FAIL_INVALID_OS() {
+        // given
+
+        // when & then
+        assertThatThrownBy(() -> clientAppVersionService.checkIsUpdateMandatory("linux_ubuntu", 22))
+                .isExactlyInstanceOf(VersionException.class);
+    }
+}

--- a/src/test/java/usw/suwiki/service/lecture/LectureServiceTest.java
+++ b/src/test/java/usw/suwiki/service/lecture/LectureServiceTest.java
@@ -10,13 +10,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -24,12 +20,12 @@ import usw.suwiki.domain.lecture.controller.dto.LectureWithScheduleResponse;
 import usw.suwiki.domain.lecture.domain.Lecture;
 import usw.suwiki.domain.lecture.domain.repository.LectureRepository;
 import usw.suwiki.domain.lecture.service.LectureService;
+import usw.suwiki.global.annotation.SuwikiMockitoTest;
 import usw.suwiki.global.dto.NoOffsetPaginationResponse;
 import usw.suwiki.template.lecture.LectureDetailTemplate;
 import usw.suwiki.template.lecture.LectureTemplate;
 
-@ExtendWith(MockitoExtension.class)
-@TestMethodOrder(MethodOrderer.DisplayName.class)
+@SuwikiMockitoTest
 public class LectureServiceTest {
     @InjectMocks
     LectureService lectureService;

--- a/src/test/java/usw/suwiki/service/timetable/TimetableServiceTest.java
+++ b/src/test/java/usw/suwiki/service/timetable/TimetableServiceTest.java
@@ -16,13 +16,9 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import usw.suwiki.domain.timetable.dto.request.CreateTimetableCellRequest;
 import usw.suwiki.domain.timetable.dto.request.CreateTimetableRequest;
 import usw.suwiki.domain.timetable.dto.request.CreateWholeTimetableRequest;
@@ -40,14 +36,14 @@ import usw.suwiki.domain.timetable.repository.TimetableRepository;
 import usw.suwiki.domain.timetable.service.TimetableService;
 import usw.suwiki.domain.user.user.User;
 import usw.suwiki.domain.user.user.service.UserCRUDService;
+import usw.suwiki.global.annotation.SuwikiMockitoTest;
 import usw.suwiki.global.exception.ExceptionType;
 import usw.suwiki.global.exception.errortype.TimetableException;
 import usw.suwiki.template.timetable.TimetableTemplate;
 import usw.suwiki.template.timetablecell.TimetableCellTemplate;
 import usw.suwiki.template.user.UserTemplate;
 
-@ExtendWith(MockitoExtension.class)
-@TestMethodOrder(MethodOrderer.DisplayName.class)
+@SuwikiMockitoTest
 public class TimetableServiceTest {
     @InjectMocks
     TimetableService timetableService;


### PR DESCRIPTION
## 🙋 어떤 PR인가요?
클라이언트 OS별 앱 버전 정보를 조회하는 API입니다.  
안드로이드, ios 앱에 치명적인 버그가 있을 경우를 대비한 기능이고 앱상에서 호출 후 업데이트를 해야 한다면 앱 스토어로 이동하는 흐름입니다.  

## 📝 작업 상세
- ClientAppVersion : 엔티티 및 비즈니스 로직 추가
- ClientAppVersion Repository, Service, Controller : 앱 버전 강제 업데이트 필요 여부 체크 로직(특정 OS의 가장 최신 필수 버전을 가져오는 쿼리) 추가
- 테스트 : Repository 단위 테스트, Service 단위 테스트
- 레포지토리 테스트(DataJpaTest)에 대한 공통 어노테이션, 서비스 테스트(Mockito)에 대한 공통 어노테이션 추가
- BaseTimeEntity : 여러 엔티티 객체에 흩어져있던 modifiedDate 필드를 BaseTimeEntity 객체로 이동

## 🙏 To Reviewers
앱 심사 때문에 이번주 내에 develop 브랜치 작업물을 main에 반영해야 해서 리뷰를 받기가 어려울 듯합니다,, 내일까진
정상 동작 보장될 수 있도록 가능하면 이번주내에 통합 테스트까지 해보겠습니다 @K-Diger 
테스트 공통 어노테이션 추가, BaseTimeEntity 수정되었습니다

## 🧐 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
- [x]  정상동작하는지, 테스트 통과하는지 다시 한번 확인해주세요.
