### PR TITLE
hotfix: 강의 시간표상 시간 미정된 강의들에 대한 누락 문제

### DIFF
--- a/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
+++ b/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
@@ -166,11 +166,7 @@ public class LectureService {
             boolean isThereNewSchedule = lecture.getScheduleList().stream()
                     .noneMatch(jsonLectureVO::isLectureAndPlaceScheduleEqual);
             if (isThereNewSchedule) {
-                LectureSchedule schedule = LectureSchedule.builder()
-                        .lecture(lecture)
-                        .placeSchedule(jsonLectureVO.getPlaceSchedule())
-                        .build();
-                lectureScheduleRepository.save(schedule);
+                saveOnlyValidLectureSchedule(jsonLectureVO, lecture);
             }
 
             deletedLectureScheduleList.stream()
@@ -178,12 +174,18 @@ public class LectureService {
                     .forEach(lecture::removeSchedule);
         } else {
             Lecture newLecture = jsonLectureVO.toEntity();
-            LectureSchedule.builder()
+            saveOnlyValidLectureSchedule(jsonLectureVO, newLecture);
+            lectureRepository.save(newLecture);
+        }
+    }
+
+    private void saveOnlyValidLectureSchedule(JSONLectureVO jsonLectureVO, Lecture newLecture) {
+        if (jsonLectureVO.isPlaceScheduleValid()) {
+            LectureSchedule schedule = LectureSchedule.builder()
                     .lecture(newLecture)
                     .placeSchedule(jsonLectureVO.getPlaceSchedule())
                     .build();
-
-            lectureRepository.save(newLecture);
+            lectureScheduleRepository.save(schedule);
         }
     }
 

--- a/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
+++ b/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
@@ -139,7 +139,7 @@ public class LectureService {
     @Transactional(propagation = Propagation.MANDATORY)
     public void bulkApplyJsonLectureList(List<JSONLectureVO> jsonLectureVOList) {
         List<LectureSchedule> currentSemeterLectureScheduleList = lectureRepository
-                .findAllLectureSchedulesByLectureSemesterContains("2024-1");
+                .findAllLectureSchedulesByLectureSemesterContains(currentSemester);
 
         List<LectureSchedule> deletedLectureScheduleList = resolveDeletedLectureScheduleList(
                 jsonLectureVOList,

--- a/src/main/java/usw/suwiki/global/util/loadjson/JSONLectureVO.java
+++ b/src/main/java/usw/suwiki/global/util/loadjson/JSONLectureVO.java
@@ -53,8 +53,6 @@ public class JSONLectureVO {
                 .capprType(capprType)
                 .build();
 
-        // TODO fix: LectureSchedule 생성. 이 메서드 말고 밖에서 만들어야 할듯
-
         return Lecture.builder()
                 .name(lectureName)
                 .type(lectureType)
@@ -63,6 +61,12 @@ public class JSONLectureVO {
                 .majorType(majorType)
                 .lectureDetail(lectureDetail)
                 .build();
+    }
+
+
+
+    public boolean isPlaceScheduleValid() {
+        return !(placeSchedule.equals("null") || placeSchedule.isEmpty());
     }
 
     public boolean isLectureAndPlaceScheduleEqual(LectureSchedule lectureSchedule) {

--- a/src/main/java/usw/suwiki/global/util/loadjson/USWTermResolver.java
+++ b/src/main/java/usw/suwiki/global/util/loadjson/USWTermResolver.java
@@ -4,6 +4,16 @@ import org.json.simple.JSONObject;
 
 public final class USWTermResolver {
     private static final String[] KEYWORDS_TO_REMOVE = {"재수강", "비대면수업", "대면수업", "혼합수업"};
+
+    // TODO refactor: REGEX 검사
+    // 변환에 필요한 최소한의 스트링 형식입니다.
+    // 해당 형식에 맞지 않는다면 수원대측에서 형식을 바꾼 것이므로 더 이상 호환되지 않기 때문에 예외를 발생시키고 적재를 중단해야 합니다.
+    // https://regexr.com/7rq1g
+    // pass : "강의실107-1(수6,7,8)" "강의실 B215(화5,6,7 수5,6,7)"
+    // pass : "(월1,2)" -> "미정(월1,2)"
+    // fail : "강의실(1,2)" "강의실 월1,2" "강의실107(요일아님6,7,8)" "요일없음(1,2)" "강의실103(화5,6),강의실103"
+//    private static final String PLACE_SCHEDULE_REGEX = "^([\\s가-힣A-Za-z\\d-]+\\([월화수목금토일]\\d+(?:,\\d+)*.*?\\))+$";
+
     private static final String ESTABLISHED_YEAR = "subjtEstbYear";
     private static final String ESTABLISHED_SEMESTER = "subjtEstbSmrCd";
     private static final String PLACE_SCHEDULE = "timtSmryCn";


### PR DESCRIPTION
## 🙋 어떤 PR인가요?
USW 포털 강의 데이터상에서 place_schedule이 "강의실(요일1,2,3)" 패턴이 아닌 "(요일1,2,3)" 패턴인 케이스에서 버그가 발생했었습니다. 
기존에는 REGEX 검사를 해서 "강의실(요일1,2,3), ..." 패턴과 일치하는 것만을 시간표 데이터로 응답하였던 것이 문제였습니다.  
USW에서 데이터 형태를 바꿀 케이스를 생각해서 만들었던 조건인데, 강의 데이터 적재 로직에서 어느정도 검증된다고 생각해서 제거하게 됐습니다.

## 📝 작업 상세
- 강의 데이터 적재 로직 : place_schedule이 존재하지 않는 json 강의 데이터들에 대해 place_schedule을 "null" 스트링으로 저장하는 로직 수정 -> place_schedule 저장 안 하도록
- 강의 시간표 리스트 조회 로직 : place_schedule 중에서 place가 존재하지 않는 케이스의 경우 "미정"을 반환하도록 수정


## 🙏 To Reviewers

## 🧐 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
- [x]  정상동작하는지, 테스트 통과하는지 다시 한번 확인해주세요.
